### PR TITLE
docs: fix inconsistencies and add missing details to README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ tests/
     valid/                 — 11 roundtrip test fixtures (parse→print→parse→compare)
     invalid/               — 4 error test fixtures (expect non-zero exit)
 examples/
-  example.dub              — Core language features
+  example.dub              — Core language features (also run as a roundtrip test)
   example2.dub             — Tuples, vectors, for-range
   interface.dub            — Interface syntax
   sieve.dub                — Sieve of Eratosthenes

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Currently implements lexing, parsing, AST construction, and pretty-printing.
 - `type` declarations for interfaces with method signatures
 - Methods declared as `fun TypeName::methodName()`
 - Member calls (`obj.method(args)`) and qualified calls (`ns::func(args)`)
-- Generic types (`vector<byte>`)
+- Generic types (`vector<int>`, `vector<byte>`, etc.)
 - C-style `for` loops: `for var i = 0; i < n; ++i { ... }`
 - Range-based `for` loops: `for var item = range(collection) { ... }`
 - `if`/`else` statements
 - `continue`
-- Arithmetic, comparison, and logical operators (`&&`, `||`, `!`)
+- Arithmetic operators (including `%`), comparison, and logical operators (`&&`, `||`, `!`)
 - Compound assignment operators (`+=`, `-=`, `*=`, `/=`)
 - Pre/post increment/decrement (`++`/`--`)
 - String literals and the built-in `string` type


### PR DESCRIPTION
- README: mention % in arithmetic operators, expand generic types example
- CLAUDE.md: note that example.dub also runs as a roundtrip test (12 total)