### PR TITLE
feat(parser): implement three-expression for loop

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -52,6 +52,7 @@ valid_cases = [
     'string_type',
     'interface',
     'example2',
+    'for_expr_loop',
 ]
 
 foreach name : valid_cases

--- a/src/parser.y
+++ b/src/parser.y
@@ -459,12 +459,11 @@ for_stmt
         }
     | FOR expr ';' expr ';' expr compound_stmt
         {
-            // Not yet implemented. Release allocated nodes to avoid leaks.
-            delete static_cast<ExprNode*>($2);
-            delete static_cast<ExprNode*>($4);
-            delete static_cast<ExprNode*>($6);
-            delete static_cast<StmtNode*>($7);
-            $$ = nullptr;
+            $$ = new ForStmtNode(
+                new ExprStmtNode(static_cast<ExprNode*>($2)),
+                static_cast<ExprNode*>($4),
+                static_cast<ExprNode*>($6),
+                static_cast<StmtNode*>($7));
         }
     ;
 

--- a/tests/fixtures/valid/for_expr_loop.dub
+++ b/tests/fixtures/valid/for_expr_loop.dub
@@ -1,0 +1,9 @@
+// Three-expression for loop: for init_expr; condition; increment { body }
+fun sum(n : int) -> int {
+    var result : int = 0;
+    var i : int = 0;
+    for i = 1; i <= n; i = i + 1 {
+        result = result + i;
+    }
+    return result;
+}


### PR DESCRIPTION
Wire up the existing grammar rule for `for expr; expr; expr { body }`, wrapping the init expression in ExprStmtNode to satisfy the StmtNode* slot in ForStmtNode. Adds a roundtrip test fixture.