### PR TITLE
feat(ast): store and print method parameters

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -196,6 +196,7 @@ class MethodDeclNode : public DeclNode {
 public:
     std::string typeName;
     std::string name;
+    std::vector<std::unique_ptr<ParamNode>> params;
     std::string returnType;
     std::unique_ptr<StmtNode> body;
     MethodDeclNode(std::string tn, std::string n, std::string rt, StmtNode* b)

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,6 +53,7 @@ valid_cases = [
     'interface',
     'example2',
     'for_expr_loop',
+    'method_params',
 ]
 
 foreach name : valid_cases

--- a/src/parser.y
+++ b/src/parser.y
@@ -150,9 +150,7 @@ func_decl
                 std::move(*name), std::string{}, static_cast<StmtNode*>($6));
             auto params = std::unique_ptr<std::vector<ParamNode*>>(
                 static_cast<std::vector<ParamNode*>*>($4));
-            if (params) {
-                for (auto* p : *params) node->params.emplace_back(p);
-            }
+            for (auto* p : *params) node->params.emplace_back(p);
             $$ = node;
         }
     | FUN IDENTIFIER '(' param_list_opt ')' ARROW type_spec compound_stmt
@@ -163,9 +161,7 @@ func_decl
                 std::move(*name), std::move(*retType), static_cast<StmtNode*>($8));
             auto params = std::unique_ptr<std::vector<ParamNode*>>(
                 static_cast<std::vector<ParamNode*>*>($4));
-            if (params) {
-                for (auto* p : *params) node->params.emplace_back(p);
-            }
+            for (auto* p : *params) node->params.emplace_back(p);
             $$ = node;
         }
     ;
@@ -303,30 +299,26 @@ method_decl
         {
             auto typeName   = std::unique_ptr<std::string>($2);
             auto methodName = std::unique_ptr<std::string>($4);
-            // param_list_opt is not yet represented in MethodDeclNode; free to avoid leaks.
-            auto params = std::unique_ptr<std::vector<ParamNode*>>(
-                static_cast<std::vector<ParamNode*>*>($6));
-            if (params) {
-                for (auto* p : *params) delete p;
-            }
-            $$ = new MethodDeclNode(
+            auto* node = new MethodDeclNode(
                 std::move(*typeName), std::move(*methodName),
                 std::string{}, static_cast<StmtNode*>($8));
+            auto params = std::unique_ptr<std::vector<ParamNode*>>(
+                static_cast<std::vector<ParamNode*>*>($6));
+            for (auto* p : *params) node->params.emplace_back(p);
+            $$ = node;
         }
     | FUN IDENTIFIER COLONCOLON IDENTIFIER '(' param_list_opt ')' ARROW type_spec compound_stmt
         {
             auto typeName   = std::unique_ptr<std::string>($2);
             auto methodName = std::unique_ptr<std::string>($4);
             auto retType    = std::unique_ptr<std::string>($9);
-            // param_list_opt is not yet represented in MethodDeclNode; free to avoid leaks.
-            auto params = std::unique_ptr<std::vector<ParamNode*>>(
-                static_cast<std::vector<ParamNode*>*>($6));
-            if (params) {
-                for (auto* p : *params) delete p;
-            }
-            $$ = new MethodDeclNode(
+            auto* node = new MethodDeclNode(
                 std::move(*typeName), std::move(*methodName),
                 std::move(*retType), static_cast<StmtNode*>($10));
+            auto params = std::unique_ptr<std::vector<ParamNode*>>(
+                static_cast<std::vector<ParamNode*>*>($6));
+            for (auto* p : *params) node->params.emplace_back(p);
+            $$ = node;
         }
     ;
 

--- a/src/printer.cpp
+++ b/src/printer.cpp
@@ -10,6 +10,14 @@
 void Printer::pad() const { out_ << std::string(indent_, ' '); }
 void Printer::pad(int extra) const { out_ << std::string(indent_ + extra, ' '); }
 
+void Printer::printParams(const std::vector<std::unique_ptr<ParamNode>>& params) {
+    for (bool first = true; const auto& p : params) {
+        if (!first) out_ << ", ";
+        p->accept(*this);
+        first = false;
+    }
+}
+
 // ── Expressions ───────────────────────────────────────────────────────────────
 
 void Printer::visit(const IdentifierNode& node) { out_ << node.name; }
@@ -110,12 +118,7 @@ void Printer::visit(const ParamNode& node) {
 
 void Printer::visit(const FuncDeclNode& node) {
     out_ << std::format("fun {}(", node.name);
-    // C++20 init-statement in range-for for comma separation.
-    for (bool first = true; const auto& p : node.params) {
-        if (!first) out_ << ", ";
-        p->accept(*this);
-        first = false;
-    }
+    printParams(node.params);
     out_ << ')';
     if (!node.returnType.empty()) out_ << std::format(" -> {}", node.returnType);
     out_ << ' ';
@@ -141,7 +144,9 @@ void Printer::visit(const StructTypeNode& node) {
 }
 
 void Printer::visit(const MethodDeclNode& node) {
-    out_ << std::format("fun {}::{}()", node.typeName, node.name);
+    out_ << std::format("fun {}::{}(", node.typeName, node.name);
+    printParams(node.params);
+    out_ << ')';
     if (!node.returnType.empty()) out_ << std::format(" -> {}", node.returnType);
     out_ << ' ';
     node.body->accept(*this);
@@ -167,11 +172,7 @@ void Printer::visit(const InterfaceTypeNode& node) {
 
 void Printer::visit(const InterfaceMethodNode& node) {
     out_ << node.name << '(';
-    for (bool first = true; const auto& p : node.params) {
-        if (!first) out_ << ", ";
-        p->accept(*this);
-        first = false;
-    }
+    printParams(node.params);
     out_ << ')';
     if (!node.returnType.empty()) out_ << std::format(" -> {}", node.returnType);
     out_ << ';';

--- a/src/printer.h
+++ b/src/printer.h
@@ -1,7 +1,9 @@
 #ifndef PRINTER_H
 #define PRINTER_H
 
+#include <memory>
 #include <ostream>
+#include <vector>
 
 #include "visitor.h"
 
@@ -53,6 +55,8 @@ private:
     void pad() const;
     // Emit `indent_ + extra` spaces without changing indent_.
     void pad(int extra) const;
+    // Emit a comma-separated parameter list (no surrounding parens).
+    void printParams(const std::vector<std::unique_ptr<ParamNode>>& params);
 };
 
 #endif  // PRINTER_H

--- a/tests/fixtures/valid/method_params.dub
+++ b/tests/fixtures/valid/method_params.dub
@@ -1,0 +1,16 @@
+// Methods with parameters — all parameter forms.
+type counter = struct {
+    value : int;
+}
+
+fun counter::add(n : int) {
+    value = value + n;
+}
+
+fun counter::mul(n : int) -> int {
+    return value * n;
+}
+
+fun counter::addTwo(a : int, b : int) {
+    value = value + a + b;
+}


### PR DESCRIPTION
MethodDeclNode now holds params like FuncDeclNode does. Parser rules transfer params via emplace_back instead of deleting them; printer uses a new printParams helper shared by FuncDeclNode, MethodDeclNode, and InterfaceMethodNode. Roundtrip test added.