### PR TITLE
feat(parser): add break statement and void return

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -37,6 +37,7 @@ class tuple_var_decl_node;
 class tuple_assign_stmt_node;
 class for_range_stmt_node;
 class continue_stmt_node;
+class break_stmt_node;
 class init_list_expr_node;
 
 // Global root for the AST - defined in ast.cpp
@@ -315,6 +316,12 @@ public:
 };
 
 class continue_stmt_node : public stmt_node {
+public:
+    void accept(visitor& v) const override { v.visit(*this); }
+    [[nodiscard]] bool needs_semicolon() const noexcept override { return true; }
+};
+
+class break_stmt_node : public stmt_node {
 public:
     void accept(visitor& v) const override { v.visit(*this); }
     [[nodiscard]] bool needs_semicolon() const noexcept override { return true; }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -29,6 +29,7 @@
 "if"                 { return IF; }
 "else"               { return ELSE; }
 "continue"           { return CONTINUE; }
+"break"              { return BREAK; }
 
 "<="                 { return LE; }
 ">="                 { return GE; }

--- a/src/meson.build
+++ b/src/meson.build
@@ -54,6 +54,8 @@ valid_cases = [
     'example2',
     'for_expr_loop',
     'method_params',
+    'break',
+    'void_return',
 ]
 
 foreach name : valid_cases

--- a/src/parser.y
+++ b/src/parser.y
@@ -40,7 +40,7 @@ void yyerror(const char* s);
 
 %token <stringval> IDENTIFIER
 %token <intval> NUMBER
-%token FUN VAR REF RETURN FOR IF ELSE CONTINUE
+%token FUN VAR REF RETURN FOR IF ELSE CONTINUE BREAK
 %token LE GE EQ NE AND OR
 %token INC DEC
 %token PLUS_EQ MINUS_EQ STAR_EQ SLASH_EQ
@@ -53,7 +53,7 @@ void yyerror(const char* s);
 %type <node> for_stmt return_stmt var_decl
 %type <node> type_decl struct_type program method_decl
 %type <node> interface_type interface_method
-%type <node> if_stmt tuple_var_decl tuple_assign_stmt for_range_stmt continue_stmt
+%type <node> if_stmt tuple_var_decl tuple_assign_stmt for_range_stmt continue_stmt break_stmt
 %type <node> tuple_expr
 %type <paramvec> param_list_opt param_list
 %type <stringval> type_spec method_name
@@ -125,6 +125,7 @@ stmt
     | return_stmt
     | if_stmt
     | continue_stmt
+    | break_stmt
     | tuple_assign_stmt
     | expr ';'
         {
@@ -464,6 +465,8 @@ return_stmt
         { $$ = new return_stmt_node(static_cast<expr_node*>($2)); }
     | RETURN tuple_expr ';'
         { $$ = new return_stmt_node(static_cast<expr_node*>($2)); }
+    | RETURN ';'
+        { $$ = new return_stmt_node(nullptr); }
     ;
 
 if_stmt
@@ -483,6 +486,11 @@ if_stmt
 continue_stmt
     : CONTINUE ';'
         { $$ = new continue_stmt_node(); }
+    ;
+
+break_stmt
+    : BREAK ';'
+        { $$ = new break_stmt_node(); }
     ;
 
 for_range_stmt

--- a/src/printer.cpp
+++ b/src/printer.cpp
@@ -69,8 +69,11 @@ void printer::visit(const var_decl_node& node) {
 // Prints without trailing semicolon; compound_stmt_node adds it via
 // needs_semicolon().
 void printer::visit(const return_stmt_node& node) {
-    out_ << "return ";
-    node.value->accept(*this);
+    out_ << "return";
+    if (node.value) {
+        out_ << ' ';
+        node.value->accept(*this);
+    }
 }
 
 // Grammar: for var_decl expr ; expr body
@@ -234,6 +237,8 @@ void printer::visit(const if_stmt_node& node) {
 }
 
 void printer::visit(const continue_stmt_node& /*node*/) { out_ << "continue"; }
+
+void printer::visit(const break_stmt_node& /*node*/) { out_ << "break"; }
 
 void printer::visit(const init_list_expr_node& node) {
     out_ << '{';

--- a/src/printer.h
+++ b/src/printer.h
@@ -44,6 +44,7 @@ public:
     void visit(const tuple_assign_stmt_node&) override;
     void visit(const for_range_stmt_node&) override;
     void visit(const continue_stmt_node&) override;
+    void visit(const break_stmt_node&) override;
     void visit(const init_list_expr_node&) override;
     void visit(const program_node&) override;
 

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -33,6 +33,7 @@ class tuple_var_decl_node;
 class tuple_assign_stmt_node;
 class for_range_stmt_node;
 class continue_stmt_node;
+class break_stmt_node;
 class init_list_expr_node;
 class program_node;
 
@@ -72,6 +73,7 @@ public:
     virtual void visit(const tuple_assign_stmt_node&) = 0;
     virtual void visit(const for_range_stmt_node&) = 0;
     virtual void visit(const continue_stmt_node&) = 0;
+    virtual void visit(const break_stmt_node&) = 0;
     virtual void visit(const init_list_expr_node&) = 0;
     virtual void visit(const program_node&) = 0;
     virtual ~visitor() = default;

--- a/tests/fixtures/valid/break.dub
+++ b/tests/fixtures/valid/break.dub
@@ -1,0 +1,8 @@
+fun search(n: int) -> int {
+    for var i = 0; i < n; ++i {
+        if (i == 5) {
+            break;
+        }
+    }
+    return 0;
+}

--- a/tests/fixtures/valid/void_return.dub
+++ b/tests/fixtures/valid/void_return.dub
@@ -1,0 +1,6 @@
+fun early_exit(x: int) {
+    if (x == 0) {
+        return;
+    }
+    return;
+}


### PR DESCRIPTION
Implement break as a mirror of continue, and allow bare return; for void functions. Adds roundtrip fixtures for both features.