### PR TITLE
feat(parser): extend tuple assignment LHS to support index expressions

### DIFF
--- a/examples/quicksort.dub
+++ b/examples/quicksort.dub
@@ -5,13 +5,6 @@
 // recurses on the two sub-ranges.  The vector is passed by reference
 // throughout so all modifications are visible to the caller.
 
-// Swap v[i] and v[j] in place.
-fun swap(v : ref vector<int>, i : int, j : int) {
-    var tmp = v[i];
-    v[i] = v[j];
-    v[j] = tmp;
-}
-
 // Partition v[lo..hi) around pivot v[hi-1].
 // Moves every element <= pivot to the left of the pivot and returns
 // the final index of the pivot.
@@ -21,10 +14,10 @@ fun partition(v : ref vector<int>, lo : int, hi : int) -> int {
     for var j = lo; j < hi - 1; ++j {
         if (v[j] <= pivot) {
             i += 1;
-            swap(v, i, j);
+            v[i], v[j] = v[j], v[i];
         }
     }
-    swap(v, i + 1, hi - 1);
+    v[i + 1], v[hi - 1] = v[hi - 1], v[i + 1];
     return i + 1;
 }
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -307,10 +307,10 @@ public:
 
 class tuple_assign_stmt_node : public stmt_node {
 public:
-    std::vector<std::string> lhs_names;
+    std::vector<std::unique_ptr<expr_node>> lhs_exprs;
     std::unique_ptr<expr_node> rhs;
-    tuple_assign_stmt_node(std::vector<std::string> ns, expr_node* r)
-        : lhs_names(std::move(ns)), rhs(r) {}
+    tuple_assign_stmt_node(std::vector<std::unique_ptr<expr_node>> lhs, expr_node* r)
+        : lhs_exprs(std::move(lhs)), rhs(r) {}
     void accept(visitor& v) const override { v.visit(*this); }
     [[nodiscard]] bool needs_semicolon() const noexcept override { return true; }
 };

--- a/src/meson.build
+++ b/src/meson.build
@@ -63,6 +63,9 @@ valid_cases = [
     'init_list',
     'nested_loops_break',
     'tuple_typed_params',
+    'tuple_assign_index',
+    'tuple_assign_mixed',
+    'tuple_assign_chain_index',
 ]
 
 foreach name : valid_cases

--- a/src/parser.y
+++ b/src/parser.y
@@ -54,12 +54,12 @@ void yyerror(const char* s);
 %type <node> type_decl struct_type program method_decl
 %type <node> interface_type interface_method
 %type <node> if_stmt tuple_var_decl tuple_assign_stmt for_range_stmt continue_stmt break_stmt
-%type <node> tuple_expr
+%type <node> tuple_expr tuple_rhs
 %type <paramvec> param_list_opt param_list
 %type <stringval> type_spec method_name
 %type <nodevec> stmt_list_opt stmt_list field_list_opt field_list
 %type <nodevec> interface_method_list interface_method_list_opt
-%type <nodevec> arg_list_opt arg_list
+%type <nodevec> arg_list_opt arg_list lvalue_list
 %type <namevec> name_list
 
 %left '=' PLUS_EQ MINUS_EQ STAR_EQ SLASH_EQ
@@ -517,6 +517,22 @@ name_list
         }
     ;
 
+// %prec '=' resolves the shift/reduce conflict when '=' follows the last
+// lvalue_list element: the reduction (same level, %left) beats the shift.
+lvalue_list
+    : expr ',' expr %prec '='
+        {
+            $$ = new std::vector<ast_node*>();
+            $$->push_back($1);
+            $$->push_back($3);
+        }
+    | lvalue_list ',' expr %prec '='
+        {
+            $$ = $1;
+            $$->push_back($3);
+        }
+    ;
+
 tuple_var_decl
     : VAR name_list '=' expr ';'
         {
@@ -528,21 +544,21 @@ tuple_var_decl
         }
     ;
 
+// Accepts both a tuple expression and a plain expression on the RHS of a
+// tuple assignment, mirroring the same duality in return_stmt.
+tuple_rhs
+    : expr       { $$ = $1; }
+    | tuple_expr { $$ = $1; }
+    ;
+
 tuple_assign_stmt
-    : name_list '=' tuple_expr ';'
+    : lvalue_list '=' tuple_rhs ';'
         {
-            auto names_raw = std::unique_ptr<std::vector<std::string*>>($1);
-            std::vector<std::string> names;
-            for (auto* s : *names_raw) { names.push_back(std::move(*s)); delete s; }
-            $$ = new tuple_assign_stmt_node(std::move(names),
-                                            static_cast<expr_node*>($3));
-        }
-    | name_list '=' expr ';'
-        {
-            auto names_raw = std::unique_ptr<std::vector<std::string*>>($1);
-            std::vector<std::string> names;
-            for (auto* s : *names_raw) { names.push_back(std::move(*s)); delete s; }
-            $$ = new tuple_assign_stmt_node(std::move(names),
+            auto lhs_raw = std::unique_ptr<std::vector<ast_node*>>(
+                static_cast<std::vector<ast_node*>*>($1));
+            std::vector<std::unique_ptr<expr_node>> lhs;
+            for (auto* n : *lhs_raw) lhs.emplace_back(static_cast<expr_node*>(n));
+            $$ = new tuple_assign_stmt_node(std::move(lhs),
                                             static_cast<expr_node*>($3));
         }
     ;

--- a/src/printer.cpp
+++ b/src/printer.cpp
@@ -270,9 +270,9 @@ void printer::visit(const tuple_var_decl_node& node) {
 }
 
 void printer::visit(const tuple_assign_stmt_node& node) {
-    for (bool first = true; const auto& name : node.lhs_names) {
+    for (bool first = true; const auto& lhs : node.lhs_exprs) {
         if (!first) out_ << ", ";
-        out_ << name;
+        lhs->accept(*this);
         first = false;
     }
     out_ << " = ";

--- a/tests/fixtures/valid/tuple_assign_chain_index.dub
+++ b/tests/fixtures/valid/tuple_assign_chain_index.dub
@@ -1,0 +1,3 @@
+fun rotate3(v : ref vector<int>, i : int, j : int, k : int) {
+    v[i], v[j], v[k] = v[j], v[k], v[i];
+}

--- a/tests/fixtures/valid/tuple_assign_index.dub
+++ b/tests/fixtures/valid/tuple_assign_index.dub
@@ -1,0 +1,3 @@
+fun swap(v : ref vector<int>, i : int, j : int) {
+    v[i], v[j] = v[j], v[i];
+}

--- a/tests/fixtures/valid/tuple_assign_mixed.dub
+++ b/tests/fixtures/valid/tuple_assign_mixed.dub
@@ -1,0 +1,3 @@
+fun pop_front(v : ref vector<int>, out : ref int) {
+    out, v[0] = v[0], 0;
+}


### PR DESCRIPTION
Replace name_list (identifiers only) with lvalue_list (general exprs) on the tuple assignment LHS, enabling patterns like v[i], v[j] = v[j], v[i]. Add %prec '=' to resolve the shift/reduce conflict. Introduce tuple_rhs to unify the two tuple_assign_stmt alternatives. Update quicksort to inline swaps using the new syntax and drop the swap helper. Add 3 roundtrip fixtures.