### PR TITLE
chore(doc): update tuple assignment docs to reflect lvalue LHS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ ast_node
 - **Continue / Break**: `continue;`, `break;`
 - **Generic types**: `vector<int>`, `vector<byte>`, etc. are supported in type positions (parameters, return types, variable declarations)
 - **Operators**: arithmetic (including `%`), comparison, logical (`&&`, `||`, `!`), compound assignment (`+=` `-=` `*=` `/=`), pre/post `++`/`--`, indexing `[]`
-- **Tuples**: returned as `return a, b;`, destructured as `var x, y = f();`
+- **Tuples**: returned as `return a, b;`, destructured as `var x, y = f();`, assigned with general lvalue LHS (`v[i], v[j] = v[j], v[i];`)
 
 ### Test Infrastructure
 
@@ -90,7 +90,7 @@ ast_node
 tests/
   run_test.py              — Python test runner
   fixtures/
-    valid/                 — 22 roundtrip test fixtures (parse→print→parse→compare)
+    valid/                 — 25 roundtrip test fixtures (parse→print→parse→compare)
     invalid/               — 6 error test fixtures (expect non-zero exit)
 examples/
   example.dub              — Core language features (also a roundtrip test)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently implements lexing, parsing, AST construction, and pretty-printing.
 - Functions with inferred or explicit type annotations
 - `ref` parameters (pass-by-reference)
 - `var` declarations with optional type annotations (`var x = 10;`, `var x: int = 10;`)
-- Tuple variables and assignments (`var x, y = f();`, `return a, b;`)
+- Tuple variables and assignments (`var x, y = f();`, `return a, b;`, `v[i], v[j] = v[j], v[i];`)
 - Init-list expressions (`var v: vector<int> = {};`)
 - `type` declarations for structs with optional single inheritance
 - `type` declarations for interfaces with method signatures


### PR DESCRIPTION
Document the general lvalue LHS support for tuple assignments added in #9, and fix the stale fixture count in CLAUDE.md (22 → 25).