### PR TITLE
feat(parser): add field access expression (obj.field)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ ast_node
 ├── expr_node
 │   ├── identifier_node, number_node, string_node
 │   ├── binary_op_node, unary_op_node, assign_node, compound_assign_node
-│   ├── call_node, member_call_node, qualified_call_node
+│   ├── call_node, member_call_node, member_access_node, qualified_call_node
 │   ├── index_node, tuple_expr_node, init_list_expr_node
 │
 ├── stmt_node
@@ -75,6 +75,7 @@ ast_node
 - **Variables**: `var x = 10;`, `var x: int = 10;`, tuple `var x, y = func();`, init-list `var v: vector<int> = {};`
 - **Type declarations**: structs (`type point = struct { x: int; y: int; }`), inheritance (`struct : ParentType`), interfaces (`type reader = interface { read(sz: int) -> vector<byte>; }`)
 - **Methods**: `fun TypeName::methodName(p: int) -> ReturnType { ... }`, called as `obj.method(args)`. Parameters are stored in `method_decl_node` (same as `func_decl_node`) and printed by the shared `print_params` helper.
+- **Field access**: `obj.field`, supports chaining (`obj.child.value`) and assignment (`obj.field = expr`)
 - **Qualified calls**: `ns::func(args)`
 - **C-style for loop**: two forms (no parens, no semicolon before body): `for var i = 0; i < n; ++i { ... }` (var-decl init) and `for expr; expr; expr { ... }` (expression init, e.g. `for i = 1; i <= n; i = i + 1 { ... }`).
 - **Range-based for**: `for var item = range(collection) { ... }`
@@ -90,7 +91,7 @@ ast_node
 tests/
   run_test.py              — Python test runner
   fixtures/
-    valid/                 — 25 roundtrip test fixtures (parse→print→parse→compare)
+    valid/                 — 28 roundtrip test fixtures (parse→print→parse→compare)
     invalid/               — 6 error test fixtures (expect non-zero exit)
 examples/
   example.dub              — Core language features (also a roundtrip test)

--- a/src/ast.h
+++ b/src/ast.h
@@ -27,6 +27,7 @@ class method_decl_node;
 class interface_type_node;
 class interface_method_node;
 class member_call_node;
+class member_access_node;
 class qualified_call_node;
 class call_node;
 class index_node;
@@ -237,6 +238,14 @@ public:
     std::string method;
     std::vector<std::unique_ptr<expr_node>> args;
     member_call_node(expr_node* obj, std::string m) : object(obj), method(std::move(m)) {}
+    void accept(visitor& v) const override { v.visit(*this); }
+};
+
+class member_access_node : public expr_node {
+public:
+    std::unique_ptr<expr_node> object;
+    std::string field;
+    member_access_node(expr_node* obj, std::string f) : object(obj), field(std::move(f)) {}
     void accept(visitor& v) const override { v.visit(*this); }
 };
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -66,6 +66,9 @@ valid_cases = [
     'tuple_assign_index',
     'tuple_assign_mixed',
     'tuple_assign_chain_index',
+    'field_access',
+    'field_access_chain',
+    'field_access_assign',
 ]
 
 foreach name : valid_cases

--- a/src/parser.y
+++ b/src/parser.y
@@ -667,6 +667,12 @@ expr
             }
             $$ = node;
         }
+    | expr '.' IDENTIFIER
+        {
+            auto fname = std::unique_ptr<std::string>($3);
+            $$ = new member_access_node(
+                static_cast<expr_node*>($1), std::move(*fname));
+        }
     | expr '.' method_name '(' arg_list_opt ')'
         {
             auto mname = std::unique_ptr<std::string>($3);

--- a/src/parser_types.h
+++ b/src/parser_types.h
@@ -32,6 +32,7 @@ class type_body_node;
 class interface_type_node;
 class interface_method_node;
 class member_call_node;
+class member_access_node;
 class qualified_call_node;
 class call_node;
 class index_node;

--- a/src/printer.cpp
+++ b/src/printer.cpp
@@ -192,6 +192,11 @@ void printer::visit(const member_call_node& node) {
     out_ << ')';
 }
 
+void printer::visit(const member_access_node& node) {
+    node.object->accept(*this);
+    out_ << '.' << node.field;
+}
+
 void printer::visit(const qualified_call_node& node) {
     out_ << std::format("{}::{}(", node.qualifier, node.name);
     for (bool first = true; const auto& a : node.args) {

--- a/src/printer.h
+++ b/src/printer.h
@@ -34,6 +34,7 @@ public:
     void visit(const interface_type_node&) override;
     void visit(const interface_method_node&) override;
     void visit(const member_call_node&) override;
+    void visit(const member_access_node&) override;
     void visit(const qualified_call_node&) override;
     void visit(const call_node&) override;
     void visit(const index_node&) override;

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -23,6 +23,7 @@ class type_decl_node;
 class interface_type_node;
 class interface_method_node;
 class member_call_node;
+class member_access_node;
 class qualified_call_node;
 class call_node;
 class index_node;
@@ -63,6 +64,7 @@ public:
     virtual void visit(const interface_type_node&) = 0;
     virtual void visit(const interface_method_node&) = 0;
     virtual void visit(const member_call_node&) = 0;
+    virtual void visit(const member_access_node&) = 0;
     virtual void visit(const qualified_call_node&) = 0;
     virtual void visit(const call_node&) = 0;
     virtual void visit(const index_node&) = 0;

--- a/tests/fixtures/valid/field_access.dub
+++ b/tests/fixtures/valid/field_access.dub
@@ -1,0 +1,13 @@
+type point = struct {
+    x: int;
+    y: int;
+}
+
+fun make_point() -> point {
+}
+
+fun main() {
+    var p = make_point();
+    var a = p.x;
+    var b = p.y;
+}

--- a/tests/fixtures/valid/field_access_assign.dub
+++ b/tests/fixtures/valid/field_access_assign.dub
@@ -1,0 +1,13 @@
+type point = struct {
+    x: int;
+    y: int;
+}
+
+fun make_point() -> point {
+}
+
+fun main() {
+    var p = make_point();
+    p.x = 10;
+    p.y = (p.x + 5);
+}

--- a/tests/fixtures/valid/field_access_chain.dub
+++ b/tests/fixtures/valid/field_access_chain.dub
@@ -1,0 +1,16 @@
+type inner = struct {
+    value: int;
+}
+
+type outer = struct {
+    child: inner;
+}
+
+fun make_outer() -> outer {
+}
+
+fun main() {
+    var o = make_outer();
+    var v = o.child.value;
+    var s = (o.child.value + 1);
+}


### PR DESCRIPTION
## Summary

- Add `member_access_node` (`expr '.' IDENTIFIER`) for struct field access
- Support chained access (`o.child.value`) and assignment to fields (`p.x = 10`)
- No parser conflicts — `.` left-associativity resolves method call vs field access naturally (shift to `(` → method call, otherwise → field access)

## Changes

- **`src/ast.h`** — new `member_access_node` class (object + field name)
- **`src/visitor.h`** — add `visit(const member_access_node&)` pure virtual
- **`src/parser_types.h`** — forward declaration
- **`src/parser.y`** — grammar rule `expr '.' IDENTIFIER` before existing member call rule
- **`src/printer.h` / `printer.cpp`** — printer outputs `object.field`
- **`src/meson.build`** — register 3 new test fixtures
- **`CLAUDE.md`** — document field access in language features and AST hierarchy

## Test plan

- [x] 3 new roundtrip fixtures: `field_access`, `field_access_chain`, `field_access_assign`
- [x] All 36 tests pass (33 existing + 3 new)
- [x] Full pipeline green (format → build → tidy → test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)