### PR TITLE
feat(parser): support variable declaration without initializer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ ast_node
 
 - **Functions**: inferred types (`fun f(x)`), explicit types (`fun f(x: int) -> int`)
 - **Parameters**: by-value (`p`), by-value typed (`p: int`), by-ref (`p: ref`), by-ref typed (`p: int ref`)
-- **Variables**: `var x = 10;`, `var x: int = 10;`, tuple `var x, y = func();`, init-list `var v: vector<int> = {};`
+- **Variables**: `var x = 10;`, `var x: int = 10;`, `var x: int;` (no init), tuple `var x, y = func();`, init-list `var v: vector<int> = {};`
 - **Type declarations**: structs (`type point = struct { x: int; y: int; }`), inheritance (`struct : ParentType`), interfaces (`type reader = interface { read(sz: int) -> vector<byte>; }`)
 - **Methods**: `fun TypeName::methodName(p: int) -> ReturnType { ... }`, called as `obj.method(args)`. Parameters are stored in `method_decl_node` (same as `func_decl_node`) and printed by the shared `print_params` helper.
 - **Field access**: `obj.field`, supports chaining (`obj.child.value`) and assignment (`obj.field = expr`)

--- a/src/meson.build
+++ b/src/meson.build
@@ -69,6 +69,8 @@ valid_cases = [
     'field_access',
     'field_access_chain',
     'field_access_assign',
+    'var_no_init',
+    'var_no_init_generic',
 ]
 
 foreach name : valid_cases

--- a/src/parser.y
+++ b/src/parser.y
@@ -439,6 +439,12 @@ var_decl
             }
             $$ = new var_decl_node(std::move(*name), std::move(*type), node);
         }
+    | VAR IDENTIFIER ':' type_spec ';'
+        {
+            auto name = std::unique_ptr<std::string>($2);
+            auto type = std::unique_ptr<std::string>($4);
+            $$ = new var_decl_node(std::move(*name), std::move(*type), nullptr);
+        }
     ;
 
 for_stmt

--- a/src/printer.cpp
+++ b/src/printer.cpp
@@ -58,12 +58,12 @@ void printer::visit(const expr_stmt_node& node) { node.expr->accept(*this); }
 // Prints without trailing semicolon; compound_stmt_node adds it via
 // needs_semicolon().
 void printer::visit(const var_decl_node& node) {
-    if (node.type.empty()) {
-        out_ << std::format("var {} = ", node.name);
-    } else {
-        out_ << std::format("var {} : {} = ", node.name, node.type);
+    out_ << "var " << node.name;
+    if (!node.type.empty()) out_ << " : " << node.type;
+    if (node.init) {
+        out_ << " = ";
+        node.init->accept(*this);
     }
-    node.init->accept(*this);
 }
 
 // Prints without trailing semicolon; compound_stmt_node adds it via

--- a/tests/fixtures/valid/field_access.dub
+++ b/tests/fixtures/valid/field_access.dub
@@ -3,11 +3,8 @@ type point = struct {
     y: int;
 }
 
-fun make_point() -> point {
-}
-
 fun main() {
-    var p = make_point();
+    var p: point;
     var a = p.x;
     var b = p.y;
 }

--- a/tests/fixtures/valid/field_access_chain.dub
+++ b/tests/fixtures/valid/field_access_chain.dub
@@ -6,11 +6,8 @@ type outer = struct {
     child: inner;
 }
 
-fun make_outer() -> outer {
-}
-
 fun main() {
-    var o = make_outer();
+    var o: outer;
     var v = o.child.value;
     var s = (o.child.value + 1);
 }

--- a/tests/fixtures/valid/var_no_init.dub
+++ b/tests/fixtures/valid/var_no_init.dub
@@ -5,6 +5,7 @@ type point = struct {
 
 fun main() {
     var p: point;
+    var x: int;
     p.x = 10;
-    p.y = (p.x + 5);
+    x = p.x;
 }

--- a/tests/fixtures/valid/var_no_init_generic.dub
+++ b/tests/fixtures/valid/var_no_init_generic.dub
@@ -1,0 +1,4 @@
+fun main() {
+    var v: vector<int>;
+    var s: vector<string>;
+}


### PR DESCRIPTION
## Summary

- Add `var x: type;` grammar rule — typed variable declaration without initializer (passes `nullptr` for init)
- Handle nullable `init` in printer with simplified single-flow logic
- Update field access fixtures to use `var p: point;` instead of `make_point()` workaround
- Add 2 new roundtrip fixtures: `var_no_init` and `var_no_init_generic`

## Tests

- Fixtures added: `var_no_init.dub`, `var_no_init_generic.dub`
- All existing tests pass: `ninja -C build test` (38/38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)