### PR TITLE
chore: add GitHub Actions CI workflow for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flex bison meson ninja-build clang clang-format
+
+      - name: Setup build
+        run: meson setup build
+        env:
+          CC: clang
+          CXX: clang++
+
+      - name: Check formatting
+        run: |
+          ninja -C build format
+          if ! git diff --exit-code; then
+            echo "::error::Code is not formatted. Run 'ninja -C build format' locally."
+            exit 1
+          fi
+
+      - name: Build
+        run: ninja -C build
+
+      - name: Test
+        run: ninja -C build test

--- a/meson.build
+++ b/meson.build
@@ -35,12 +35,12 @@ if clang_tidy.found()
         'src/printer.h', 'src/printer.cpp',
         'src/main.cpp',
     )
-    run_target('tidy',
-        command: [clang_tidy,
-                  '-p', meson.project_build_root(),
-                  '--extra-arg=--sysroot=' + run_command('xcrun', '--show-sdk-path', check: true).stdout().strip(),
-                  tidy_sources],
-    )
+    tidy_args = [clang_tidy, '-p', meson.project_build_root()]
+    if host_machine.system() == 'darwin'
+        tidy_args += '--extra-arg=--sysroot=' + run_command('xcrun', '--show-sdk-path', check: true).stdout().strip()
+    endif
+    tidy_args += tidy_sources
+    run_target('tidy', command: tidy_args)
 endif
 
 # ── clang-format target ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that runs on every PR to `main`
- Pipeline: format check (blocker — fails if code isn't formatted) → build → test
- Uses Ubuntu with Clang, Flex, Bison, Meson/Ninja

## Tests

- Fixtures added: none
- All existing tests pass: `ninja -C build test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)