### PR TITLE
chore(build): align Meson build with best practices

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('dubsar', ['cpp', 'c'],
     version: '0.1.0',
-    default_options: ['cpp_std=c++20']
+    default_options: ['cpp_std=c++20', 'warning_level=2', 'werror=true']
 )
 
 # Find flex and bison.
@@ -20,26 +20,25 @@ if cxx.get_id() != 'clang'
     error('This project requires clang compiler')
 endif
 
-add_project_arguments('-Wextra', '-Werror', language: 'cpp')
-
 # Build sources
 subdir('src')
 
 # ── clang-tidy target ────────────────────────────────────────────────────────
 
+hand_written_sources = files(
+    'src/ast.h', 'src/ast.cpp',
+    'src/visitor.h',
+    'src/printer.h', 'src/printer.cpp',
+    'src/main.cpp',
+)
+
 clang_tidy = find_program('clang-tidy', required: false)
 if clang_tidy.found()
-    tidy_sources = files(
-        'src/ast.h', 'src/ast.cpp',
-        'src/visitor.h',
-        'src/printer.h', 'src/printer.cpp',
-        'src/main.cpp',
-    )
     tidy_args = [clang_tidy, '-p', meson.project_build_root()]
     if host_machine.system() == 'darwin'
         tidy_args += '--extra-arg=--sysroot=' + run_command('xcrun', '--show-sdk-path', check: true).stdout().strip()
     endif
-    tidy_args += tidy_sources
+    tidy_args += hand_written_sources
     run_target('tidy', command: tidy_args)
 endif
 
@@ -47,13 +46,7 @@ endif
 
 clang_format = find_program('clang-format', required: false)
 if clang_format.found()
-    fmt_sources = files(
-        'src/ast.h', 'src/ast.cpp',
-        'src/visitor.h',
-        'src/printer.h', 'src/printer.cpp',
-        'src/main.cpp',
-    )
     run_target('format',
-        command: [clang_format, '-i', fmt_sources],
+        command: [clang_format, '-i', hand_written_sources],
     )
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,25 +1,28 @@
-# Generate parser from bison (output .cpp so meson uses C++ compiler)
-parser_cpp = custom_target('parser_cpp',
-    output: 'parser.cpp',
-    command: [bison, '-d', '-o', '@OUTPUT@', '@INPUT@'],
+src_inc = include_directories('.')
+
+# Generate parser from bison (output .cpp so meson uses C++ compiler).
+# Declaring both outputs lets Meson track parser.hpp as a real dependency.
+parser = custom_target('parser',
+    output: ['parser.cpp', 'parser.hpp'],
+    command: [bison, '-d', '-o', '@OUTPUT0@', '@INPUT@'],
     input: 'parser.y'
 )
 
-# Generate lexer from flex (output .cpp so meson uses C++ compiler)
-# Depends on parser_cpp because the generated lexer.cpp includes parser.hpp.
+# Generate lexer from flex (output .cpp so meson uses C++ compiler).
+# The lexer includes parser.hpp; Meson infers the dependency automatically
+# because parser.hpp is a declared output of the parser target.
 lexer_cpp = custom_target('lexer_cpp',
     output: 'lexer.cpp',
     command: [flex, '-o', '@OUTPUT@', '@INPUT@'],
     input: 'lexer.l',
-    depends: [parser_cpp]
 )
 
 # Generated sources are compiled without -Werror to silence warnings in
 # flex/bison output that we cannot control.
 generated_lib = static_library('generated',
-    parser_cpp,
+    parser,
     lexer_cpp,
-    include_directories: include_directories('.'),
+    include_directories: src_inc,
     cpp_args: ['-Wno-error', '-w'],
 )
 
@@ -27,7 +30,7 @@ dubsar = executable('dubsar',
     'main.cpp',
     'ast.cpp',
     'printer.cpp',
-    include_directories: include_directories('.'),
+    include_directories: src_inc,
     link_with: generated_lib,
     install: false
 )


### PR DESCRIPTION
## Summary

- Declare `parser.hpp` as an explicit Bison output so Meson tracks the header dependency directly, removing the fragile `depends:` workaround on the lexer target
- Use built-in `warning_level` and `werror` options instead of raw compiler args, letting users override via `-Dwerror=false` without editing the build file
- Deduplicate the hand-written source list shared by the tidy and format targets
- Share a single `include_directories` across `generated_lib` and the executable

## Tests

- Fixtures added: none
- All existing tests pass: `ninja -C build test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)