### PR TITLE
feat(parser): add base type keywords and sized integers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ The pipeline is: `.dub` source file → **Lexer** → **Parser** → **AST** →
 
 ### Source files (`src/`)
 
-- `lexer.l` — Flex lexer. Keywords: `fun`, `var`, `ref`, `return`, `for`, `type`, `struct`, `string`, `interface`, `if`, `else`, `continue`, `break`. Operators include arithmetic (including `%`), comparison, logical, pre/post increment/decrement, compound assignment (`+=`, `-=`, `*=`, `/=`), `::`, `->`, and indexing `[]`. Supports `//` and `/* */` comments. Includes the generated `parser.hpp` for `YYSTYPE` and token constants (no local union definition).
+- `lexer.l` — Flex lexer. Keywords: `fun`, `var`, `ref`, `return`, `for`, `type`, `struct`, `string`, `int`, `bool`, `byte`, `float`, `double`, `char`, `integer`, `interface`, `if`, `else`, `continue`, `break`. Operators include arithmetic (including `%`), comparison, logical, pre/post increment/decrement, compound assignment (`+=`, `-=`, `*=`, `/=`), `::`, `->`, and indexing `[]`. Supports `//` and `/* */` comments. Includes the generated `parser.hpp` for `YYSTYPE` and token constants (no local union definition).
 - `parser.y` — Bison grammar. Produces a `program_node*` in the global `root` variable. Handles: function/method/type declarations at top level, `var` declarations, `for`/for-range loops, `if`/`else`, `return`, `continue`, `break`, compound statements, tuple declarations/assignments, and expressions. Uses `%code requires {}` to embed forward declarations (from `parser_types.h`) into the generated `parser.hpp`. Uses `%destructor` rules (one per union type tag) to delete raw pointers discarded during error recovery. The build uses `-Wextra -Werror`; generated Flex/Bison sources are compiled without `-Werror` to suppress unavoidable warnings.
 - `ast.h` / `ast.cpp` — AST node class hierarchy. `program_node` is the root. All nodes implement `accept(visitor&)` for the visitor pattern. `ast.cpp` defines the global `root` variable.
 - `visitor.h` — Abstract `visitor` base class with `visit()` overloads for every node type.
@@ -81,6 +81,8 @@ ast_node
 - **Range-based for**: `for var item = range(collection) { ... }`
 - **If/else**: `if cond { ... }` / `if cond { ... } else { ... }`
 - **Continue / Break**: `continue;`, `break;`
+- **Base types**: `int`, `bool`, `byte`, `float`, `double`, `char`, `string` are reserved keywords usable in type positions
+- **Sized integers**: `integer<64>` (signed), `integer<+64>` (unsigned); bare `integer` is not valid
 - **Generic types**: `vector<int>`, `vector<byte>`, etc. are supported in type positions (parameters, return types, variable declarations)
 - **Operators**: arithmetic (including `%`), comparison, logical (`&&`, `||`, `!`), compound assignment (`+=` `-=` `*=` `/=`), pre/post `++`/`--`, indexing `[]`
 - **Tuples**: returned as `return a, b;`, destructured as `var x, y = f();`, assigned with general lvalue LHS (`v[i], v[j] = v[j], v[i];`)
@@ -91,8 +93,8 @@ ast_node
 tests/
   run_test.py              — Python test runner
   fixtures/
-    valid/                 — 28 roundtrip test fixtures (parse→print→parse→compare)
-    invalid/               — 6 error test fixtures (expect non-zero exit)
+    valid/                 — 30 roundtrip test fixtures (parse→print→parse→compare)
+    invalid/               — 7 error test fixtures (expect non-zero exit)
 examples/
   example.dub              — Core language features (also a roundtrip test)
   example2.dub             — Tuples, vectors, for-range

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -30,6 +30,13 @@
 "else"               { return ELSE; }
 "continue"           { return CONTINUE; }
 "break"              { return BREAK; }
+"int"                { return INT_TYPE; }
+"bool"               { return BOOL_TYPE; }
+"byte"               { return BYTE_TYPE; }
+"float"              { return FLOAT_TYPE; }
+"double"             { return DOUBLE_TYPE; }
+"char"               { return CHAR_TYPE; }
+"integer"            { return INTEGER_TYPE; }
 
 "<="                 { return LE; }
 ">="                 { return GE; }

--- a/src/meson.build
+++ b/src/meson.build
@@ -74,6 +74,8 @@ valid_cases = [
     'field_access_assign',
     'var_no_init',
     'var_no_init_generic',
+    'base_types',
+    'sized_int',
 ]
 
 foreach name : valid_cases
@@ -102,6 +104,7 @@ invalid_cases = [
     'incomplete_fun',
     'break_no_semicolon',
     'continue_no_semicolon',
+    'bare_integer',
 ]
 
 foreach name : invalid_cases

--- a/src/parser.y
+++ b/src/parser.y
@@ -45,6 +45,7 @@ void yyerror(const char* s);
 %token INC DEC
 %token PLUS_EQ MINUS_EQ STAR_EQ SLASH_EQ
 %token TYPE STRUCT STRING_TYPE INTERFACE
+%token INT_TYPE BOOL_TYPE BYTE_TYPE FLOAT_TYPE DOUBLE_TYPE CHAR_TYPE INTEGER_TYPE
 %token COLONCOLON
 %token ARROW
 %token <stringval> STRING_LITERAL
@@ -56,7 +57,7 @@ void yyerror(const char* s);
 %type <node> if_stmt tuple_var_decl tuple_assign_stmt for_range_stmt continue_stmt break_stmt
 %type <node> tuple_expr tuple_rhs
 %type <paramvec> param_list_opt param_list
-%type <stringval> type_spec method_name
+%type <stringval> type_spec method_name base_type sized_int_type inner_type
 %type <nodevec> stmt_list_opt stmt_list field_list_opt field_list
 %type <nodevec> interface_method_list interface_method_list_opt
 %type <nodevec> arg_list_opt arg_list lvalue_list
@@ -268,7 +269,7 @@ interface_method
 
 method_name
     : IDENTIFIER { $$ = $1; }
-    | STRING_TYPE { $$ = new std::string("string"); }
+    | base_type  { $$ = $1; }
     ;
 
 field_list_opt
@@ -398,19 +399,43 @@ param_list
     ;
 
 type_spec
-    : IDENTIFIER { $$ = $1; }
-    | STRING_TYPE { $$ = new std::string("string"); }
-    | IDENTIFIER '<' IDENTIFIER '>'
+    : IDENTIFIER                            { $$ = $1; }
+    | base_type                             { $$ = $1; }
+    | sized_int_type                        { $$ = $1; }
+    | IDENTIFIER '<' inner_type '>'
         {
             auto outer = std::unique_ptr<std::string>($1);
             auto inner = std::unique_ptr<std::string>($3);
             $$ = new std::string(std::format("{}<{}>", *outer, *inner));
         }
-    | IDENTIFIER '<' STRING_TYPE '>'
+    | IDENTIFIER '<' sized_int_type '>'
         {
             auto outer = std::unique_ptr<std::string>($1);
-            $$ = new std::string(std::format("{}<string>", *outer));
+            auto inner = std::unique_ptr<std::string>($3);
+            $$ = new std::string(std::format("{}<{}>", *outer, *inner));
         }
+    ;
+
+base_type
+    : STRING_TYPE   { $$ = new std::string("string"); }
+    | INT_TYPE      { $$ = new std::string("int"); }
+    | BOOL_TYPE     { $$ = new std::string("bool"); }
+    | BYTE_TYPE     { $$ = new std::string("byte"); }
+    | FLOAT_TYPE    { $$ = new std::string("float"); }
+    | DOUBLE_TYPE   { $$ = new std::string("double"); }
+    | CHAR_TYPE     { $$ = new std::string("char"); }
+    ;
+
+sized_int_type
+    : INTEGER_TYPE '<' NUMBER '>'
+        { $$ = new std::string(std::format("integer<{}>", $3)); }
+    | INTEGER_TYPE '<' '+' NUMBER '>'
+        { $$ = new std::string(std::format("integer<+{}>", $4)); }
+    ;
+
+inner_type
+    : IDENTIFIER    { $$ = $1; }
+    | base_type     { $$ = $1; }
     ;
 
 var_decl

--- a/tests/fixtures/invalid/bare_integer.dub
+++ b/tests/fixtures/invalid/bare_integer.dub
@@ -1,0 +1,3 @@
+fun bad(x: integer) -> int {
+    return 0;
+}

--- a/tests/fixtures/valid/base_types.dub
+++ b/tests/fixtures/valid/base_types.dub
@@ -1,0 +1,19 @@
+type point = struct {
+    x: int;
+    y: float;
+    z: double;
+}
+
+fun convert(c: char, b: byte, flag: bool) -> int {
+    var result: int = 0;
+    var pi: float;
+    var precise: double = 0;
+    return result;
+}
+
+fun use_generics(v: vector<int>, chars: vector<char>) -> vector<bool> {
+    var floats: vector<float> = {};
+    var doubles: vector<double> = {};
+    var bytes: vector<byte> = {};
+    return v;
+}

--- a/tests/fixtures/valid/sized_int.dub
+++ b/tests/fixtures/valid/sized_int.dub
@@ -1,0 +1,10 @@
+fun use_sized(a: integer<64>, b: integer<+64>) -> integer<32> {
+    var x: integer<64> = 0;
+    var y: integer<+32>;
+    return x;
+}
+
+fun generic_sized(v: vector<integer<64>>) -> vector<integer<+64>> {
+    var w: vector<integer<+64>> = {};
+    return w;
+}


### PR DESCRIPTION
## Summary

- Promote `int`, `bool`, `byte`, `float`, `double`, `char` to reserved keywords (lexer + parser)
- Add `integer<N>` (signed) and `integer<+N>` (unsigned) sized integer syntax; bare `integer` is rejected
- Rewrite `type_spec` and `method_name` non-terminals to use new `base_type`, `sized_int_type`, and `inner_type` rules

## Tests

- Fixtures added: `base_types` (roundtrip), `sized_int` (roundtrip), `bare_integer` (error)
- All existing tests pass: `ninja -C build test` (41/41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)