### PR TITLE
docs: fix stale roundtrip fixture count in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ ast_node
 tests/
   run_test.py              — Python test runner
   fixtures/
-    valid/                 — 30 roundtrip test fixtures (parse→print→parse→compare)
+    valid/                 — 32 roundtrip test fixtures (parse→print→parse→compare)
     invalid/               — 7 error test fixtures (expect non-zero exit)
 examples/
   example.dub              — Core language features (also a roundtrip test)


### PR DESCRIPTION
## Summary

- Fix stale test fixture count in CLAUDE.md: `30` → `32` to match the two valid fixtures added in #16

## Tests

- Fixtures added: none
- All existing tests pass: `ninja -C build test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)