### PR TITLE
feat: add semantic pass with HM type inference and row types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**dubsar** is a compiler frontend (WiP) for a custom programming language also called "dubsar". It implements lexing, parsing, AST construction, and pretty-printing via a visitor pattern. The language supports functions, variables, structs with inheritance, interfaces, methods, control flow (if/else, for, for-range, continue, break), tuples, and type inference.
+**dubsar** is a compiler frontend (WiP) for a custom programming language also called "dubsar". It implements lexing, parsing, AST construction, pretty-printing via a visitor pattern, and a semantic pass with OCaml-inspired type inference using Hindley-Milner unification and row types. The language supports functions, variables, structs with inheritance, interfaces, methods, control flow (if/else, for, for-range, continue, break), tuples, and type inference.
 
 ## Build System
 
@@ -20,6 +20,9 @@ ninja -C build
 # Run on a .dub source file
 ./build/src/dubsar examples/example.dub
 
+# Run without type checking (parse + print only)
+./build/src/dubsar --no-check examples/example.dub
+
 # Run tests
 ninja -C build test
 ```
@@ -28,17 +31,25 @@ The build system defines roundtrip tests (parse → print → parse → compare)
 
 ## Architecture
 
-The pipeline is: `.dub` source file → **Lexer** → **Parser** → **AST** → **Printer** → stdout.
+The pipeline is: `.dub` source file → **Lexer** → **Parser** → **AST** → **Resolver** → **Type Checker** → **Printer** → stdout.
+
+The `--no-check` flag skips the resolver and type checker passes.
 
 ### Source files (`src/`)
 
 - `lexer.l` — Flex lexer. Keywords: `fun`, `var`, `ref`, `return`, `for`, `type`, `struct`, `string`, `int`, `bool`, `byte`, `float`, `double`, `char`, `integer`, `interface`, `if`, `else`, `continue`, `break`. Operators include arithmetic (including `%`), comparison, logical, pre/post increment/decrement, compound assignment (`+=`, `-=`, `*=`, `/=`), `::`, `->`, and indexing `[]`. Supports `//` and `/* */` comments. Includes the generated `parser.hpp` for `YYSTYPE` and token constants (no local union definition).
-- `parser.y` — Bison grammar. Produces a `program_node*` in the global `root` variable. Handles: function/method/type declarations at top level, `var` declarations, `for`/for-range loops, `if`/`else`, `return`, `continue`, `break`, compound statements, tuple declarations/assignments, and expressions. Uses `%code requires {}` to embed forward declarations (from `parser_types.h`) into the generated `parser.hpp`. Uses `%destructor` rules (one per union type tag) to delete raw pointers discarded during error recovery. The build uses `-Wextra -Werror`; generated Flex/Bison sources are compiled without `-Werror` to suppress unavoidable warnings.
-- `ast.h` / `ast.cpp` — AST node class hierarchy. `program_node` is the root. All nodes implement `accept(visitor&)` for the visitor pattern. `ast.cpp` defines the global `root` variable.
+- `parser.y` — Bison grammar. Produces a `program_node*` in the global `root` variable. Handles: function/method/type declarations at top level, `var` declarations, `for`/for-range loops, `if`/`else`, `return`, `continue`, `break`, compound statements, tuple declarations/assignments, and expressions. Uses `%code requires {}` to embed forward declarations (from `parser_types.h`) into the generated `parser.hpp`. Uses `%destructor` rules (one per union type tag) to delete raw pointers discarded during error recovery. The `loc()` template sets `node->line = yylineno` on every allocated AST node.
+- `ast.h` / `ast.cpp` — AST node class hierarchy. `program_node` is the root. All nodes have `int line` for source locations. All nodes implement `accept(visitor&)` for the visitor pattern. `ast.cpp` defines the global `root` variable.
 - `visitor.h` — Abstract `visitor` base class with `visit()` overloads for every node type.
 - `printer.h` / `printer.cpp` — `printer` concrete visitor for AST pretty-printing. Adds parentheses around all binary ops for round-trip stability (avoids any precedence ambiguity on re-parse).
 - `parser_types.h` — Forward declarations of all AST node classes. Included via `%code requires {}` in `parser.y` so it appears in the generated `parser.hpp`, making the declarations available to any file that includes that header (including the lexer).
-- `main.cpp` — Entry point: opens a file, calls `yyparse()`, then calls `printer` on the AST root.
+- `types.h` / `types.cpp` — Type IR hierarchy (`type_t` base, `prim_type_t`, `sized_int_type_t`, `type_var_t`, `fun_type_t`, `tuple_type_t`, `generic_type_t`, `row_type_t`, `named_type_t`). Includes `parse_type_string()` to convert opaque AST type strings into the type IR. Primitive types are singletons.
+- `unify.h` / `unify.cpp` — Unification engine (`type_env`). Implements HM-style unification with occurs check, Rémy-style row unification for struct/interface polymorphism, and generalize/instantiate for let-polymorphism. Types use `shared_ptr` with union-find.
+- `diagnostics.h` / `diagnostics.cpp` — Error/warning collection with source locations. Resolution errors are hard errors (exit 1); type inference mismatches are warnings (non-fatal).
+- `symbol_table.h` / `symbol_table.cpp` — Scoped symbol table (`push_scope`/`pop_scope`/`bind`/`lookup`) and type registry (`register_type`/`lookup_type`) with function registry.
+- `resolver.h` / `resolver.cpp` — Name resolution visitor. Two sub-passes: (1) register all type names, (2) fill in struct fields, interface methods, function signatures, resolve inheritance. Structs become closed rows, interfaces become open rows.
+- `type_checker.h` / `type_checker.cpp` — Type inference visitor. Infers expression types via HM unification, binds variables in scoped symbol table, checks function/method bodies. Expression types are stored in a side table (`unordered_map<const ast_node*, type_ptr>`) to avoid modifying AST node classes. Method bodies have implicit access to their struct's fields. Generalization at top-level function boundaries.
+- `main.cpp` — Entry point: opens a file, calls `yyparse()`, runs resolver + type checker (unless `--no-check`), then calls `printer` on the AST root.
 
 ### Build-generated files (`build/src/`)
 
@@ -47,7 +58,7 @@ The pipeline is: `.dub` source file → **Lexer** → **Parser** → **AST** →
 ### AST Node Hierarchy
 
 ```
-ast_node
+ast_node (int line)
 ├── expr_node
 │   ├── identifier_node, number_node, string_node
 │   ├── binary_op_node, unary_op_node, assign_node, compound_assign_node
@@ -67,6 +78,30 @@ ast_node
         ├── struct_type_node
         └── interface_type_node (with interface_method_node)
 ```
+
+### Type IR Hierarchy
+
+```
+type_t (abstract)
+├── prim_type_t          — int, bool, byte, float, double, char, string (singletons)
+├── sized_int_type_t     — integer<N> with signedness flag
+├── type_var_t           — unification variable (id, bound, level)
+├── fun_type_t           — (T1, T2, ...) -> T_ret
+├── tuple_type_t         — (T1, T2, ...)
+├── generic_type_t       — name + type args (e.g. vector<int>)
+├── row_type_t           — { label1: T1, ... | tail } (tail = nullptr or type_var)
+└── named_type_t         — reference to declared struct/interface
+```
+
+### Semantic Pass Design
+
+- **Structs are closed rows, interfaces are open rows** — interface satisfaction works via row unification where the open tail binds to residual fields
+- **`ref` is calling convention, not a type** — `ref int` has type `int`; `is_ref` stays on `param_node`/`symbol_entry` only
+- **Expression types in side table** — avoids modifying 28+ AST node classes; printer and roundtrip tests unaffected
+- **Method bodies bind struct fields** — methods have implicit access to their type's fields in scope
+- **Top-level let-polymorphism** — un-annotated top-level functions get generalized (e.g. `fun id(x) { return x; }` → `∀α. α → α`)
+- **Permissive inference** — undefined functions/variables get fresh type vars (no stdlib yet); type mismatches are warnings, not hard errors
+- **Resolution errors are hard errors** — duplicate type/function names cause exit code 1
 
 ### Language Features
 
@@ -93,8 +128,8 @@ ast_node
 tests/
   run_test.py              — Python test runner
   fixtures/
-    valid/                 — 32 roundtrip test fixtures (parse→print→parse→compare)
-    invalid/               — 7 error test fixtures (expect non-zero exit)
+    valid/                 — 35 roundtrip test fixtures (parse→print→parse→compare)
+    invalid/               — 9 error test fixtures (expect non-zero exit)
 examples/
   example.dub              — Core language features (also a roundtrip test)
   example2.dub             — Tuples, vectors, for-range

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,12 @@ hand_written_sources = files(
     'src/ast.h', 'src/ast.cpp',
     'src/visitor.h',
     'src/printer.h', 'src/printer.cpp',
+    'src/types.h', 'src/types.cpp',
+    'src/unify.h', 'src/unify.cpp',
+    'src/diagnostics.h', 'src/diagnostics.cpp',
+    'src/symbol_table.h', 'src/symbol_table.cpp',
+    'src/resolver.h', 'src/resolver.cpp',
+    'src/type_checker.h', 'src/type_checker.cpp',
     'src/main.cpp',
 )
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -46,6 +46,7 @@ extern std::unique_ptr<program_node> root;
 
 class ast_node {
 public:
+    int line = 0;
     virtual void accept(visitor& v) const = 0;
     [[nodiscard]] virtual bool needs_semicolon() const noexcept { return false; }
     virtual ~ast_node() = default;

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -1,0 +1,36 @@
+#include "diagnostics.h"
+
+#include <algorithm>
+#include <format>
+
+#include "ast.h"
+
+void diagnostics::error(const ast_node& node, std::string message) {
+    entries_.push_back({severity::error, node.line, std::move(message)});
+}
+
+void diagnostics::error(int line, std::string message) {
+    entries_.push_back({severity::error, line, std::move(message)});
+}
+
+void diagnostics::warning(const ast_node& node, std::string message) {
+    entries_.push_back({severity::warning, node.line, std::move(message)});
+}
+
+void diagnostics::warning(int line, std::string message) {
+    entries_.push_back({severity::warning, line, std::move(message)});
+}
+
+bool diagnostics::has_errors() const noexcept {
+    return std::ranges::any_of(entries_,
+                               [](const diag_entry& e) { return e.sev == severity::error; });
+}
+
+bool diagnostics::has_diagnostics() const noexcept { return !entries_.empty(); }
+
+void diagnostics::emit(std::ostream& err) const {
+    for (const auto& e : entries_) {
+        const char* prefix = e.sev == severity::error ? "error" : "warning";
+        err << std::format("line {}: {}: {}\n", e.line, prefix, e.message);
+    }
+}

--- a/src/diagnostics.h
+++ b/src/diagnostics.h
@@ -1,0 +1,31 @@
+#ifndef DIAGNOSTICS_H
+#define DIAGNOSTICS_H
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+class ast_node;
+
+enum class severity { error, warning };
+
+class diagnostics {
+public:
+    void error(const ast_node& node, std::string message);
+    void error(int line, std::string message);
+    void warning(const ast_node& node, std::string message);
+    void warning(int line, std::string message);
+    [[nodiscard]] bool has_errors() const noexcept;
+    [[nodiscard]] bool has_diagnostics() const noexcept;
+    void emit(std::ostream& err) const;
+
+private:
+    struct diag_entry {
+        severity sev;
+        int line;
+        std::string message;
+    };
+    std::vector<diag_entry> entries_;
+};
+
+#endif  // DIAGNOSTICS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <filesystem>
 #include <format>
 #include <fstream>
@@ -7,7 +8,12 @@
 #include <string>
 
 #include "ast.h"
+#include "diagnostics.h"
 #include "printer.h"
+#include "resolver.h"
+#include "symbol_table.h"
+#include "type_checker.h"
+#include "unify.h"
 
 extern int yyparse();
 
@@ -27,12 +33,26 @@ using unique_lex_buffer = std::unique_ptr<yy_buffer_state, lex_buffer_deleter>;
 }  // namespace
 
 int main(int argc, char** argv) {
-    if (argc != 2) {
-        std::cerr << std::format("Usage: {} <input-file>\n", argv[0]);
+    bool no_check = false;
+    const char* input_file = nullptr;
+
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--no-check") == 0) {
+            no_check = true;
+        } else if (input_file == nullptr) {
+            input_file = argv[i];
+        } else {
+            std::cerr << std::format("Usage: {} [--no-check] <input-file>\n", argv[0]);
+            return 1;
+        }
+    }
+
+    if (input_file == nullptr) {
+        std::cerr << std::format("Usage: {} [--no-check] <input-file>\n", argv[0]);
         return 1;
     }
 
-    const std::filesystem::path input_path{argv[1]};
+    const std::filesystem::path input_path{input_file};
 
     std::ifstream file{input_path};
     if (!file) {
@@ -49,6 +69,26 @@ int main(int argc, char** argv) {
     }
 
     if (root) {
+        // Semantic passes (unless --no-check)
+        if (!no_check) {
+            diagnostics diag;
+            symbol_table symtab;
+            type_env env;
+
+            resolver res{symtab, env, diag};
+            res.resolve(*root);
+
+            if (!diag.has_errors()) {
+                type_checker tc{symtab, env, diag};
+                root->accept(tc);
+            }
+
+            if (diag.has_errors()) {
+                diag.emit(std::cerr);
+                return 1;
+            }
+        }
+
         printer p{std::cout};
         root->accept(p);
         std::cout << '\n';

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,6 +30,12 @@ dubsar = executable('dubsar',
     'main.cpp',
     'ast.cpp',
     'printer.cpp',
+    'types.cpp',
+    'unify.cpp',
+    'diagnostics.cpp',
+    'symbol_table.cpp',
+    'resolver.cpp',
+    'type_checker.cpp',
     include_directories: src_inc,
     link_with: generated_lib,
     install: false
@@ -76,6 +82,9 @@ valid_cases = [
     'var_no_init_generic',
     'base_types',
     'sized_int',
+    'semantic_basic',
+    'semantic_struct_method',
+    'semantic_inferred',
 ]
 
 foreach name : valid_cases
@@ -105,6 +114,8 @@ invalid_cases = [
     'break_no_semicolon',
     'continue_no_semicolon',
     'bare_integer',
+    'duplicate_type',
+    'duplicate_func',
 ]
 
 foreach name : invalid_cases

--- a/src/parser.y
+++ b/src/parser.y
@@ -21,6 +21,10 @@ extern int yylineno;
 extern char* yytext;
 void yyerror(const char* s);
 
+// Helper: set source location on a freshly-allocated AST node and return it.
+template <typename T>
+T* loc(T* node) { node->line = yylineno; return node; }
+
 // NOTE: Bison's %union is a C union and cannot hold non-trivially-destructible
 // types such as std::unique_ptr. Raw owning pointers are therefore used inside
 // grammar semantic values. Ownership is transferred into AST node unique_ptr
@@ -86,6 +90,7 @@ program
     : stmt_list_opt
         {
             root = std::make_unique<program_node>();
+            root->line = yylineno;
             auto list = std::unique_ptr<std::vector<ast_node*>>(
                 static_cast<std::vector<ast_node*>*>($1));
             if (list) {
@@ -132,7 +137,7 @@ stmt
         {
             // Wrap in expr_stmt_node to give the expression a proper stmt_node
             // type, avoiding an undefined expr_node* -> stmt_node* cast.
-            $$ = new expr_stmt_node(static_cast<expr_node*>($1));
+            $$ = loc(new expr_stmt_node(static_cast<expr_node*>($1)));
         }
     | compound_stmt
     ;
@@ -148,8 +153,8 @@ func_decl
     : FUN IDENTIFIER '(' param_list_opt ')' compound_stmt
         {
             auto name = std::unique_ptr<std::string>($2);
-            auto* node = new func_decl_node(
-                std::move(*name), std::string{}, static_cast<stmt_node*>($6));
+            auto* node = loc(new func_decl_node(
+                std::move(*name), std::string{}, static_cast<stmt_node*>($6)));
             auto params = std::unique_ptr<std::vector<param_node*>>(
                 static_cast<std::vector<param_node*>*>($4));
             for (auto* p : *params) node->params.emplace_back(p);
@@ -159,8 +164,8 @@ func_decl
         {
             auto name    = std::unique_ptr<std::string>($2);
             auto retType = std::unique_ptr<std::string>($7);
-            auto* node = new func_decl_node(
-                std::move(*name), std::move(*retType), static_cast<stmt_node*>($8));
+            auto* node = loc(new func_decl_node(
+                std::move(*name), std::move(*retType), static_cast<stmt_node*>($8)));
             auto params = std::unique_ptr<std::vector<param_node*>>(
                 static_cast<std::vector<param_node*>*>($4));
             for (auto* p : *params) node->params.emplace_back(p);
@@ -172,21 +177,21 @@ type_decl
     : TYPE IDENTIFIER '=' struct_type
         {
             auto name = std::unique_ptr<std::string>($2);
-            $$ = new type_decl_node(std::move(*name),
-                                    static_cast<type_body_node*>($4));
+            $$ = loc(new type_decl_node(std::move(*name),
+                                    static_cast<type_body_node*>($4)));
         }
     | TYPE IDENTIFIER '=' interface_type
         {
             auto name = std::unique_ptr<std::string>($2);
-            $$ = new type_decl_node(std::move(*name),
-                                    static_cast<type_body_node*>($4));
+            $$ = loc(new type_decl_node(std::move(*name),
+                                    static_cast<type_body_node*>($4)));
         }
     ;
 
 struct_type
     : STRUCT '{' field_list_opt '}'
         {
-            auto* node = new struct_type_node("", "");
+            auto* node = loc(new struct_type_node("", ""));
             auto list = std::unique_ptr<std::vector<ast_node*>>(
                 static_cast<std::vector<ast_node*>*>($3));
             if (list) {
@@ -198,7 +203,7 @@ struct_type
     | STRUCT ':' IDENTIFIER '{' field_list_opt '}'
         {
             auto parent = std::unique_ptr<std::string>($3);
-            auto* node = new struct_type_node("", std::move(*parent));
+            auto* node = loc(new struct_type_node("", std::move(*parent)));
             auto list = std::unique_ptr<std::vector<ast_node*>>(
                 static_cast<std::vector<ast_node*>*>($5));
             if (list) {
@@ -212,7 +217,7 @@ struct_type
 interface_type
     : INTERFACE '{' interface_method_list_opt '}'
         {
-            auto* node = new interface_type_node();
+            auto* node = loc(new interface_type_node());
             auto list = std::unique_ptr<std::vector<ast_node*>>(
                 static_cast<std::vector<ast_node*>*>($3));
             if (list) {
@@ -245,7 +250,7 @@ interface_method
     : method_name '(' param_list_opt ')' ';'
         {
             auto mname = std::unique_ptr<std::string>($1);
-            auto* node = new interface_method_node(std::move(*mname), std::string{});
+            auto* node = loc(new interface_method_node(std::move(*mname), std::string{}));
             auto params = std::unique_ptr<std::vector<param_node*>>(
                 static_cast<std::vector<param_node*>*>($3));
             if (params) {
@@ -257,7 +262,7 @@ interface_method
         {
             auto mname   = std::unique_ptr<std::string>($1);
             auto retType = std::unique_ptr<std::string>($6);
-            auto* node = new interface_method_node(std::move(*mname), std::move(*retType));
+            auto* node = loc(new interface_method_node(std::move(*mname), std::move(*retType)));
             auto params = std::unique_ptr<std::vector<param_node*>>(
                 static_cast<std::vector<param_node*>*>($3));
             if (params) {
@@ -283,16 +288,16 @@ field_list
             auto fieldName = std::unique_ptr<std::string>($1);
             auto fieldType = std::unique_ptr<std::string>($3);
             $$ = new std::vector<ast_node*>();
-            $$->push_back(new struct_field_node(std::move(*fieldName),
-                                                std::move(*fieldType)));
+            $$->push_back(loc(new struct_field_node(std::move(*fieldName),
+                                                std::move(*fieldType))));
         }
     | field_list IDENTIFIER ':' type_spec ';'
         {
             auto fieldName = std::unique_ptr<std::string>($2);
             auto fieldType = std::unique_ptr<std::string>($4);
             $$ = $1;
-            $$->push_back(new struct_field_node(std::move(*fieldName),
-                                                std::move(*fieldType)));
+            $$->push_back(loc(new struct_field_node(std::move(*fieldName),
+                                                std::move(*fieldType))));
         }
     ;
 
@@ -301,9 +306,9 @@ method_decl
         {
             auto typeName   = std::unique_ptr<std::string>($2);
             auto methodName = std::unique_ptr<std::string>($4);
-            auto* node = new method_decl_node(
+            auto* node = loc(new method_decl_node(
                 std::move(*typeName), std::move(*methodName),
-                std::string{}, static_cast<stmt_node*>($8));
+                std::string{}, static_cast<stmt_node*>($8)));
             auto params = std::unique_ptr<std::vector<param_node*>>(
                 static_cast<std::vector<param_node*>*>($6));
             for (auto* p : *params) node->params.emplace_back(p);
@@ -314,9 +319,9 @@ method_decl
             auto typeName   = std::unique_ptr<std::string>($2);
             auto methodName = std::unique_ptr<std::string>($4);
             auto retType    = std::unique_ptr<std::string>($9);
-            auto* node = new method_decl_node(
+            auto* node = loc(new method_decl_node(
                 std::move(*typeName), std::move(*methodName),
-                std::move(*retType), static_cast<stmt_node*>($10));
+                std::move(*retType), static_cast<stmt_node*>($10)));
             auto params = std::unique_ptr<std::vector<param_node*>>(
                 static_cast<std::vector<param_node*>*>($6));
             for (auto* p : *params) node->params.emplace_back(p);
@@ -334,67 +339,67 @@ param_list
         {
             auto name = std::unique_ptr<std::string>($1);
             $$ = new std::vector<param_node*>();
-            $$->push_back(new param_node(std::move(*name), "", false));
+            $$->push_back(loc(new param_node(std::move(*name), "", false)));
         }
     | IDENTIFIER ':' REF
         {
             auto name = std::unique_ptr<std::string>($1);
             $$ = new std::vector<param_node*>();
-            $$->push_back(new param_node(std::move(*name), "", true));
+            $$->push_back(loc(new param_node(std::move(*name), "", true)));
         }
     | IDENTIFIER ':' type_spec
         {
             auto name = std::unique_ptr<std::string>($1);
             auto type = std::unique_ptr<std::string>($3);
             $$ = new std::vector<param_node*>();
-            $$->push_back(new param_node(std::move(*name), std::move(*type), false));
+            $$->push_back(loc(new param_node(std::move(*name), std::move(*type), false)));
         }
     | IDENTIFIER ':' type_spec REF
         {
             auto name = std::unique_ptr<std::string>($1);
             auto type = std::unique_ptr<std::string>($3);
             $$ = new std::vector<param_node*>();
-            $$->push_back(new param_node(std::move(*name), std::move(*type), true));
+            $$->push_back(loc(new param_node(std::move(*name), std::move(*type), true)));
         }
     | IDENTIFIER ':' REF type_spec
         {
             auto name = std::unique_ptr<std::string>($1);
             auto type = std::unique_ptr<std::string>($4);
             $$ = new std::vector<param_node*>();
-            $$->push_back(new param_node(std::move(*name), std::move(*type), true));
+            $$->push_back(loc(new param_node(std::move(*name), std::move(*type), true)));
         }
     | param_list ',' IDENTIFIER
         {
             auto name = std::unique_ptr<std::string>($3);
             $$ = $1;
-            $$->push_back(new param_node(std::move(*name), "", false));
+            $$->push_back(loc(new param_node(std::move(*name), "", false)));
         }
     | param_list ',' IDENTIFIER ':' REF
         {
             auto name = std::unique_ptr<std::string>($3);
             $$ = $1;
-            $$->push_back(new param_node(std::move(*name), "", true));
+            $$->push_back(loc(new param_node(std::move(*name), "", true)));
         }
     | param_list ',' IDENTIFIER ':' type_spec
         {
             auto name = std::unique_ptr<std::string>($3);
             auto type = std::unique_ptr<std::string>($5);
             $$ = $1;
-            $$->push_back(new param_node(std::move(*name), std::move(*type), false));
+            $$->push_back(loc(new param_node(std::move(*name), std::move(*type), false)));
         }
     | param_list ',' IDENTIFIER ':' type_spec REF
         {
             auto name = std::unique_ptr<std::string>($3);
             auto type = std::unique_ptr<std::string>($5);
             $$ = $1;
-            $$->push_back(new param_node(std::move(*name), std::move(*type), true));
+            $$->push_back(loc(new param_node(std::move(*name), std::move(*type), true)));
         }
     | param_list ',' IDENTIFIER ':' REF type_spec
         {
             auto name = std::unique_ptr<std::string>($3);
             auto type = std::unique_ptr<std::string>($6);
             $$ = $1;
-            $$->push_back(new param_node(std::move(*name), std::move(*type), true));
+            $$->push_back(loc(new param_node(std::move(*name), std::move(*type), true)));
         }
     ;
 
@@ -442,95 +447,95 @@ var_decl
     : VAR IDENTIFIER '=' expr ';'
         {
             auto name = std::unique_ptr<std::string>($2);
-            $$ = new var_decl_node(std::move(*name), "",
-                                   static_cast<expr_node*>($4));
+            $$ = loc(new var_decl_node(std::move(*name), "",
+                                   static_cast<expr_node*>($4)));
         }
     | VAR IDENTIFIER ':' type_spec '=' expr ';'
         {
             auto name = std::unique_ptr<std::string>($2);
             auto type = std::unique_ptr<std::string>($4);
-            $$ = new var_decl_node(std::move(*name), std::move(*type),
-                                   static_cast<expr_node*>($6));
+            $$ = loc(new var_decl_node(std::move(*name), std::move(*type),
+                                   static_cast<expr_node*>($6)));
         }
     | VAR IDENTIFIER ':' type_spec '=' '{' arg_list_opt '}' ';'
         {
             auto name = std::unique_ptr<std::string>($2);
             auto type = std::unique_ptr<std::string>($4);
-            auto* node = new init_list_expr_node();
+            auto* node = loc(new init_list_expr_node());
             auto args = std::unique_ptr<std::vector<ast_node*>>(
                 static_cast<std::vector<ast_node*>*>($7));
             if (args) {
                 for (auto* a : *args) node->args.emplace_back(static_cast<expr_node*>(a));
             }
-            $$ = new var_decl_node(std::move(*name), std::move(*type), node);
+            $$ = loc(new var_decl_node(std::move(*name), std::move(*type), node));
         }
     | VAR IDENTIFIER ':' type_spec ';'
         {
             auto name = std::unique_ptr<std::string>($2);
             auto type = std::unique_ptr<std::string>($4);
-            $$ = new var_decl_node(std::move(*name), std::move(*type), nullptr);
+            $$ = loc(new var_decl_node(std::move(*name), std::move(*type), nullptr));
         }
     ;
 
 for_stmt
     : FOR var_decl expr ';' expr compound_stmt
         {
-            $$ = new for_stmt_node(
+            $$ = loc(new for_stmt_node(
                 static_cast<stmt_node*>($2),
                 static_cast<expr_node*>($3),
                 static_cast<expr_node*>($5),
-                static_cast<stmt_node*>($6));
+                static_cast<stmt_node*>($6)));
         }
     | FOR expr ';' expr ';' expr compound_stmt
         {
-            $$ = new for_stmt_node(
-                new expr_stmt_node(static_cast<expr_node*>($2)),
+            $$ = loc(new for_stmt_node(
+                loc(new expr_stmt_node(static_cast<expr_node*>($2))),
                 static_cast<expr_node*>($4),
                 static_cast<expr_node*>($6),
-                static_cast<stmt_node*>($7));
+                static_cast<stmt_node*>($7)));
         }
     ;
 
 return_stmt
     : RETURN expr ';'
-        { $$ = new return_stmt_node(static_cast<expr_node*>($2)); }
+        { $$ = loc(new return_stmt_node(static_cast<expr_node*>($2))); }
     | RETURN tuple_expr ';'
-        { $$ = new return_stmt_node(static_cast<expr_node*>($2)); }
+        { $$ = loc(new return_stmt_node(static_cast<expr_node*>($2))); }
     | RETURN ';'
-        { $$ = new return_stmt_node(nullptr); }
+        { $$ = loc(new return_stmt_node(nullptr)); }
     ;
 
 if_stmt
     : IF expr compound_stmt
         {
-            $$ = new if_stmt_node(static_cast<expr_node*>($2),
-                                  static_cast<stmt_node*>($3), nullptr);
+            $$ = loc(new if_stmt_node(static_cast<expr_node*>($2),
+                                  static_cast<stmt_node*>($3), nullptr));
         }
     | IF expr compound_stmt ELSE compound_stmt
         {
-            $$ = new if_stmt_node(static_cast<expr_node*>($2),
+            $$ = loc(new if_stmt_node(static_cast<expr_node*>($2),
                                   static_cast<stmt_node*>($3),
-                                  static_cast<stmt_node*>($5));
+                                  static_cast<stmt_node*>($5)));
         }
     ;
 
 continue_stmt
     : CONTINUE ';'
-        { $$ = new continue_stmt_node(); }
+        { $$ = loc(new continue_stmt_node()); }
     ;
 
 break_stmt
     : BREAK ';'
-        { $$ = new break_stmt_node(); }
+        { $$ = loc(new break_stmt_node()); }
     ;
 
 for_range_stmt
     : FOR VAR IDENTIFIER '=' expr compound_stmt
         {
             auto name = std::unique_ptr<std::string>($3);
-            $$ = new for_range_stmt_node(std::move(*name),
+            $$ = loc(new for_range_stmt_node(std::move(*name),
                                          static_cast<expr_node*>($5),
-                                         static_cast<stmt_node*>($6));
+                                         static_cast<stmt_node*>($6)));
         }
     ;
 
@@ -570,8 +575,8 @@ tuple_var_decl
             auto names_raw = std::unique_ptr<std::vector<std::string*>>($2);
             std::vector<std::string> names;
             for (auto* s : *names_raw) { names.push_back(std::move(*s)); delete s; }
-            $$ = new tuple_var_decl_node(std::move(names),
-                                         static_cast<expr_node*>($4));
+            $$ = loc(new tuple_var_decl_node(std::move(names),
+                                         static_cast<expr_node*>($4)));
         }
     ;
 
@@ -589,15 +594,15 @@ tuple_assign_stmt
                 static_cast<std::vector<ast_node*>*>($1));
             std::vector<std::unique_ptr<expr_node>> lhs;
             for (auto* n : *lhs_raw) lhs.emplace_back(static_cast<expr_node*>(n));
-            $$ = new tuple_assign_stmt_node(std::move(lhs),
-                                            static_cast<expr_node*>($3));
+            $$ = loc(new tuple_assign_stmt_node(std::move(lhs),
+                                            static_cast<expr_node*>($3)));
         }
     ;
 
 tuple_expr
     : expr ',' expr
         {
-            auto* node = new tuple_expr_node();
+            auto* node = loc(new tuple_expr_node());
             node->add(static_cast<expr_node*>($1));
             node->add(static_cast<expr_node*>($3));
             $$ = node;
@@ -613,7 +618,7 @@ tuple_expr
 compound_stmt
     : '{' stmt_list_opt '}'
         {
-            auto* node = new compound_stmt_node();
+            auto* node = loc(new compound_stmt_node());
             auto list = std::unique_ptr<std::vector<ast_node*>>(
                 static_cast<std::vector<ast_node*>*>($2));
             if (list) {
@@ -626,71 +631,71 @@ compound_stmt
 
 expr
     : NUMBER
-        { $$ = new number_node($1); }
+        { $$ = loc(new number_node($1)); }
     | STRING_LITERAL
         {
             auto s = std::unique_ptr<std::string>($1);
-            $$ = new string_node(std::move(*s));
+            $$ = loc(new string_node(std::move(*s)));
         }
     | IDENTIFIER
         {
             auto id = std::unique_ptr<std::string>($1);
-            $$ = new identifier_node(std::move(*id));
+            $$ = loc(new identifier_node(std::move(*id)));
         }
     | expr '+' expr
-        { $$ = new binary_op_node("+", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("+", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr '-' expr
-        { $$ = new binary_op_node("-", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("-", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr '*' expr
-        { $$ = new binary_op_node("*", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("*", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr '/' expr
-        { $$ = new binary_op_node("/", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("/", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr LE expr
-        { $$ = new binary_op_node("<=", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("<=", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr GE expr
-        { $$ = new binary_op_node(">=", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node(">=", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr '<' expr
-        { $$ = new binary_op_node("<", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("<", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr '>' expr
-        { $$ = new binary_op_node(">", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node(">", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr EQ expr
-        { $$ = new binary_op_node("==", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("==", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr NE expr
-        { $$ = new binary_op_node("!=", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("!=", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr AND expr
-        { $$ = new binary_op_node("&&", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("&&", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr OR expr
-        { $$ = new binary_op_node("||", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("||", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr '=' expr
-        { $$ = new assign_node(static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new assign_node(static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | '!' expr
-        { $$ = new unary_op_node("!", static_cast<expr_node*>($2)); }
+        { $$ = loc(new unary_op_node("!", static_cast<expr_node*>($2))); }
     | INC expr
-        { $$ = new unary_op_node("++", static_cast<expr_node*>($2)); }
+        { $$ = loc(new unary_op_node("++", static_cast<expr_node*>($2))); }
     | DEC expr
-        { $$ = new unary_op_node("--", static_cast<expr_node*>($2)); }
+        { $$ = loc(new unary_op_node("--", static_cast<expr_node*>($2))); }
     | expr INC
-        { $$ = new unary_op_node("post++", static_cast<expr_node*>($1)); }
+        { $$ = loc(new unary_op_node("post++", static_cast<expr_node*>($1))); }
     | expr DEC
-        { $$ = new unary_op_node("post--", static_cast<expr_node*>($1)); }
+        { $$ = loc(new unary_op_node("post--", static_cast<expr_node*>($1))); }
     | '(' expr ')'
         { $$ = $2; }
     | expr '%' expr
-        { $$ = new binary_op_node("%", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new binary_op_node("%", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr '[' expr ']'
-        { $$ = new index_node(static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new index_node(static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr PLUS_EQ expr
-        { $$ = new compound_assign_node("+=", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new compound_assign_node("+=", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr MINUS_EQ expr
-        { $$ = new compound_assign_node("-=", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new compound_assign_node("-=", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr STAR_EQ expr
-        { $$ = new compound_assign_node("*=", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new compound_assign_node("*=", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | expr SLASH_EQ expr
-        { $$ = new compound_assign_node("/=", static_cast<expr_node*>($1), static_cast<expr_node*>($3)); }
+        { $$ = loc(new compound_assign_node("/=", static_cast<expr_node*>($1), static_cast<expr_node*>($3))); }
     | IDENTIFIER '(' arg_list_opt ')'
         {
             auto name = std::unique_ptr<std::string>($1);
-            auto* node = new call_node(std::move(*name));
+            auto* node = loc(new call_node(std::move(*name)));
             auto args = std::unique_ptr<std::vector<ast_node*>>(
                 static_cast<std::vector<ast_node*>*>($3));
             if (args) {
@@ -701,14 +706,14 @@ expr
     | expr '.' IDENTIFIER
         {
             auto fname = std::unique_ptr<std::string>($3);
-            $$ = new member_access_node(
-                static_cast<expr_node*>($1), std::move(*fname));
+            $$ = loc(new member_access_node(
+                static_cast<expr_node*>($1), std::move(*fname)));
         }
     | expr '.' method_name '(' arg_list_opt ')'
         {
             auto mname = std::unique_ptr<std::string>($3);
-            auto* node = new member_call_node(
-                static_cast<expr_node*>($1), std::move(*mname));
+            auto* node = loc(new member_call_node(
+                static_cast<expr_node*>($1), std::move(*mname)));
             auto args = std::unique_ptr<std::vector<ast_node*>>(
                 static_cast<std::vector<ast_node*>*>($5));
             if (args) {
@@ -720,7 +725,7 @@ expr
         {
             auto qual  = std::unique_ptr<std::string>($1);
             auto mname = std::unique_ptr<std::string>($3);
-            auto* node = new qualified_call_node(std::move(*qual), std::move(*mname));
+            auto* node = loc(new qualified_call_node(std::move(*qual), std::move(*mname)));
             auto args = std::unique_ptr<std::vector<ast_node*>>(
                 static_cast<std::vector<ast_node*>*>($5));
             if (args) {

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1,0 +1,179 @@
+#include "resolver.h"
+
+#include <format>
+#include <unordered_set>
+
+#include "ast.h"
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+type_ptr resolver::resolve_type_or_fresh(const std::string& type_str) {
+    if (type_str.empty()) {
+        return env_.fresh_var();
+    }
+    return parse_type_string(type_str);
+}
+
+type_ptr resolver::build_fun_type(const std::vector<std::unique_ptr<param_node>>& params,
+                                  const std::string& return_type) {
+    std::vector<type_ptr> param_types;
+    param_types.reserve(params.size());
+    for (const auto& p : params) {
+        param_types.push_back(resolve_type_or_fresh(p->type));
+    }
+    auto ret = resolve_type_or_fresh(return_type);
+    return std::make_shared<fun_type_t>(std::move(param_types), std::move(ret));
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────────
+
+void resolver::resolve(const program_node& prog) {
+    // Pass 1: register type names
+    current_pass_ = pass::register_names;
+    prog.accept(*this);
+
+    // Pass 2: fill in details (fields, methods, function signatures)
+    current_pass_ = pass::fill_details;
+    prog.accept(*this);
+}
+
+// ── Visitor implementations ──────────────────────────────────────────────────
+
+void resolver::visit(const program_node& node) {
+    for (const auto& decl : node.declarations) {
+        decl->accept(*this);
+    }
+}
+
+void resolver::visit(const type_decl_node& node) {
+    if (current_pass_ == pass::register_names) {
+        if (symtab_.lookup_type(node.name) != nullptr) {
+            diag_.error(node, std::format("duplicate type name '{}'", node.name));
+            return;
+        }
+        type_info info;
+        info.name = node.name;
+        symtab_.register_type(node.name, std::move(info));
+    } else {
+        // Set context for the body visitor
+        current_type_name_ = node.name;
+        node.body->accept(*this);
+        current_type_name_.clear();
+    }
+}
+
+void resolver::visit(const struct_type_node& node) {
+    if (current_pass_ != pass::fill_details) {
+        return;
+    }
+
+    auto* ti = symtab_.lookup_type(current_type_name_);
+    if (ti == nullptr) {
+        return;  // Already reported
+    }
+
+    // Build field row
+    std::vector<row_entry> fields;
+    std::unordered_set<std::string> seen_fields;
+    for (const auto& f : node.fields) {
+        auto field_type = resolve_type_or_fresh(f->type);
+        if (!seen_fields.insert(f->name).second) {
+            diag_.error(*f, std::format("duplicate field '{}' in struct '{}'", f->name,
+                                        current_type_name_));
+        }
+        fields.push_back({f->name, std::move(field_type)});
+    }
+
+    // Handle parent type (inheritance)
+    type_info* parent_info = nullptr;
+    if (!node.parent.empty()) {
+        parent_info = symtab_.lookup_type(node.parent);
+        if (parent_info == nullptr) {
+            diag_.error(0, std::format("undefined parent type '{}' for struct '{}'", node.parent,
+                                       current_type_name_));
+        } else if (parent_info->is_interface) {
+            diag_.error(0, std::format("cannot inherit from interface '{}'", node.parent));
+            parent_info = nullptr;
+        } else if (parent_info->field_row != nullptr) {
+            // Prepend parent fields
+            auto* parent_row = static_cast<row_type_t*>(parent_info->field_row.get());
+            std::vector<row_entry> all_fields;
+            all_fields.reserve(parent_row->entries.size() + fields.size());
+            for (const auto& e : parent_row->entries) {
+                all_fields.push_back(e);
+            }
+            for (auto& e : fields) {
+                all_fields.push_back(std::move(e));
+            }
+            fields = std::move(all_fields);
+        }
+    }
+
+    // Structs are closed rows (tail = nullptr)
+    ti->field_row = std::make_shared<row_type_t>(std::move(fields), nullptr);
+    ti->method_row = std::make_shared<row_type_t>(std::vector<row_entry>{}, nullptr);
+    ti->parent = parent_info;
+    ti->is_interface = false;
+}
+
+void resolver::visit(const interface_type_node& node) {
+    if (current_pass_ != pass::fill_details) {
+        return;
+    }
+
+    auto* ti = symtab_.lookup_type(current_type_name_);
+    if (ti == nullptr) {
+        return;
+    }
+
+    // Interfaces have no fields, only methods.
+    // Methods form an open row (tail = fresh type variable ρ).
+    std::vector<row_entry> methods;
+    for (const auto& m : node.methods) {
+        auto method_type = build_fun_type(m->params, m->return_type);
+        methods.push_back({m->name, std::move(method_type)});
+    }
+
+    ti->field_row = std::make_shared<row_type_t>(std::vector<row_entry>{}, nullptr);
+    // Interface method row is OPEN (tail = fresh var for row polymorphism)
+    ti->method_row = std::make_shared<row_type_t>(std::move(methods), env_.fresh_var());
+    ti->is_interface = true;
+}
+
+void resolver::visit(const func_decl_node& node) {
+    if (current_pass_ != pass::fill_details) {
+        return;
+    }
+
+    if (symtab_.lookup_function(node.name) != nullptr) {
+        diag_.error(node, std::format("duplicate function name '{}'", node.name));
+        return;
+    }
+
+    auto fun_type = build_fun_type(node.params, node.return_type);
+    symtab_.register_function(node.name, fun_type);
+}
+
+void resolver::visit(const method_decl_node& node) {
+    if (current_pass_ != pass::fill_details) {
+        return;
+    }
+
+    auto* ti = symtab_.lookup_type(node.type_name);
+    if (ti == nullptr) {
+        diag_.error(node, std::format("method on undefined type '{}'", node.type_name));
+        return;
+    }
+
+    auto method_type = build_fun_type(node.params, node.return_type);
+
+    // Add method to the type's method row
+    if (ti->method_row != nullptr) {
+        auto* mr = static_cast<row_type_t*>(ti->method_row.get());
+        mr->entries.push_back({node.name, std::move(method_type)});
+    } else {
+        std::vector<row_entry> entries;
+        entries.push_back({node.name, std::move(method_type)});
+        ti->method_row = std::make_shared<row_type_t>(std::move(entries), nullptr);
+    }
+}

--- a/src/resolver.h
+++ b/src/resolver.h
@@ -1,0 +1,77 @@
+#ifndef RESOLVER_H
+#define RESOLVER_H
+
+#include "diagnostics.h"
+#include "symbol_table.h"
+#include "types.h"
+#include "unify.h"
+#include "visitor.h"
+
+// Name resolution visitor.  Two sub-passes over top-level declarations:
+//   1. Register all type names (forward-declaration effect)
+//   2. Fill in struct fields, interface methods, function signatures, parents
+class resolver : public visitor {
+public:
+    resolver(symbol_table& symtab, type_env& env, diagnostics& diag)
+        : symtab_(symtab), env_(env), diag_(diag) {}
+
+    // Entry point: runs both sub-passes.
+    void resolve(const class program_node& prog);
+
+    // visitor interface — only the top-level nodes are meaningful.
+    void visit(const class program_node&) override;
+    void visit(const class func_decl_node&) override;
+    void visit(const class method_decl_node&) override;
+    void visit(const class type_decl_node&) override;
+    void visit(const class struct_type_node&) override;
+    void visit(const class interface_type_node&) override;
+
+    // No-ops for nodes not relevant during resolution.
+    void visit(const class identifier_node&) override {}
+    void visit(const class number_node&) override {}
+    void visit(const class string_node&) override {}
+    void visit(const class binary_op_node&) override {}
+    void visit(const class unary_op_node&) override {}
+    void visit(const class assign_node&) override {}
+    void visit(const class expr_stmt_node&) override {}
+    void visit(const class param_node&) override {}
+    void visit(const class var_decl_node&) override {}
+    void visit(const class return_stmt_node&) override {}
+    void visit(const class for_stmt_node&) override {}
+    void visit(const class compound_stmt_node&) override {}
+    void visit(const class struct_field_node&) override {}
+    void visit(const class interface_method_node&) override {}
+    void visit(const class member_call_node&) override {}
+    void visit(const class member_access_node&) override {}
+    void visit(const class qualified_call_node&) override {}
+    void visit(const class call_node&) override {}
+    void visit(const class index_node&) override {}
+    void visit(const class compound_assign_node&) override {}
+    void visit(const class if_stmt_node&) override {}
+    void visit(const class tuple_expr_node&) override {}
+    void visit(const class tuple_var_decl_node&) override {}
+    void visit(const class tuple_assign_stmt_node&) override {}
+    void visit(const class for_range_stmt_node&) override {}
+    void visit(const class continue_stmt_node&) override {}
+    void visit(const class break_stmt_node&) override {}
+    void visit(const class init_list_expr_node&) override {}
+
+private:
+    symbol_table& symtab_;
+    type_env& env_;
+    diagnostics& diag_;
+
+    // Sub-pass tracking
+    enum class pass { register_names, fill_details };
+    pass current_pass_ = pass::register_names;
+
+    // Context for type_decl -> struct/interface body visitor chain
+    std::string current_type_name_;
+
+    // Helpers
+    type_ptr resolve_type_or_fresh(const std::string& type_str);
+    type_ptr build_fun_type(const std::vector<std::unique_ptr<class param_node>>& params,
+                            const std::string& return_type);
+};
+
+#endif  // RESOLVER_H

--- a/src/symbol_table.cpp
+++ b/src/symbol_table.cpp
@@ -1,0 +1,50 @@
+#include "symbol_table.h"
+
+// ── Type registry ────────────────────────────────────────────────────────────
+
+void symbol_table::register_type(const std::string& name, type_info info) {
+    types_[name] = std::move(info);
+}
+
+type_info* symbol_table::lookup_type(const std::string& name) {
+    auto it = types_.find(name);
+    if (it == types_.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
+// ── Function registry ────────────────────────────────────────────────────────
+
+void symbol_table::register_function(const std::string& name, type_ptr type) {
+    functions_[name] = std::move(type);
+}
+
+type_ptr symbol_table::lookup_function(const std::string& name) const {
+    auto it = functions_.find(name);
+    if (it == functions_.end()) {
+        return nullptr;
+    }
+    return it->second;
+}
+
+// ── Scope management ─────────────────────────────────────────────────────────
+
+void symbol_table::push_scope() { scopes_.emplace_back(); }
+
+void symbol_table::pop_scope() { scopes_.pop_back(); }
+
+void symbol_table::bind(const std::string& name, symbol_entry entry) {
+    scopes_.back()[name] = std::move(entry);
+}
+
+symbol_entry* symbol_table::lookup(const std::string& name) {
+    // Search from innermost to outermost scope
+    for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
+        auto found = it->find(name);
+        if (found != it->end()) {
+            return &found->second;
+        }
+    }
+    return nullptr;
+}

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -1,0 +1,55 @@
+#ifndef SYMBOL_TABLE_H
+#define SYMBOL_TABLE_H
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "types.h"
+
+class ast_node;
+
+// ── Symbol entry ─────────────────────────────────────────────────────────────
+
+struct symbol_entry {
+    std::string name;
+    type_ptr type;
+    bool is_ref = false;
+    const ast_node* decl_site = nullptr;
+};
+
+// ── Type info (registered struct/interface) ──────────────────────────────────
+
+struct type_info {
+    std::string name;
+    type_ptr field_row;   // row_type_t for struct fields
+    type_ptr method_row;  // row_type_t for methods
+    type_info* parent = nullptr;
+    bool is_interface = false;
+};
+
+// ── Scoped symbol table ──────────────────────────────────────────────────────
+
+class symbol_table {
+public:
+    // Type registry (global)
+    void register_type(const std::string& name, type_info info);
+    type_info* lookup_type(const std::string& name);
+
+    // Function registry (global)
+    void register_function(const std::string& name, type_ptr type);
+    type_ptr lookup_function(const std::string& name) const;
+
+    // Scope management
+    void push_scope();
+    void pop_scope();
+    void bind(const std::string& name, symbol_entry entry);
+    symbol_entry* lookup(const std::string& name);
+
+private:
+    std::unordered_map<std::string, type_info> types_;
+    std::unordered_map<std::string, type_ptr> functions_;
+    std::vector<std::unordered_map<std::string, symbol_entry>> scopes_;
+};
+
+#endif  // SYMBOL_TABLE_H

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1,0 +1,529 @@
+#include "type_checker.h"
+
+#include <algorithm>
+#include <format>
+
+#include "ast.h"
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+void type_checker::set_type(const ast_node& node, type_ptr t) { type_map_[&node] = std::move(t); }
+
+type_ptr type_checker::type_of(const ast_node* node) const {
+    auto it = type_map_.find(node);
+    if (it == type_map_.end()) {
+        return nullptr;
+    }
+    return it->second;
+}
+
+type_ptr type_checker::infer_expr(const expr_node& node) {
+    node.accept(*this);
+    auto t = type_of(&node);
+    if (t == nullptr) {
+        return env_.fresh_var();
+    }
+    return t;
+}
+
+void type_checker::try_unify(const ast_node& node, type_ptr a, type_ptr b,
+                             const std::string& context) {
+    try {
+        env_.unify(std::move(a), std::move(b));
+    } catch (const type_error& e) {
+        // Type inference issues are warnings, not hard errors.
+        // Existing fixtures test parse correctness, not type correctness.
+        diag_.warning(node, std::format("{}: {}", context, e.what()));
+    }
+}
+
+// ── Row-based member lookup ──────────────────────────────────────────────────
+
+type_ptr type_checker::lookup_field(const ast_node& /*node*/, type_ptr obj_type,
+                                    const std::string& field) {
+    auto resolved = env_.find(std::move(obj_type));
+
+    if (resolved->kind() == type_kind::named) {
+        auto* nt = static_cast<named_type_t*>(resolved.get());
+        auto* ti = symtab_.lookup_type(nt->name);
+        if (ti != nullptr && ti->field_row != nullptr) {
+            auto* row = static_cast<row_type_t*>(ti->field_row.get());
+            if (auto found = row->find_entry(field)) {
+                return found;
+            }
+        }
+        return env_.fresh_var();
+    }
+
+    if (resolved->kind() == type_kind::row) {
+        auto* row = static_cast<row_type_t*>(resolved.get());
+        if (auto found = row->find_entry(field)) {
+            return found;
+        }
+        if (row->tail != nullptr) {
+            auto field_type = env_.fresh_var();
+            row->entries.push_back({field, field_type});
+            return field_type;
+        }
+        return env_.fresh_var();
+    }
+
+    if (resolved->kind() == type_kind::type_var) {
+        auto field_type = env_.fresh_var();
+        auto tail = env_.fresh_var();
+        std::vector<row_entry> entries;
+        entries.push_back({field, field_type});
+        auto row = std::make_shared<row_type_t>(std::move(entries), tail);
+        try {
+            env_.unify(resolved, row);
+        } catch (const type_error&) {
+            // Permissive: ignore
+        }
+        return field_type;
+    }
+
+    return env_.fresh_var();
+}
+
+type_ptr type_checker::lookup_method(const ast_node& /*node*/, type_ptr obj_type,
+                                     const std::string& method) {
+    auto resolved = env_.find(std::move(obj_type));
+
+    if (resolved->kind() == type_kind::named) {
+        auto* nt = static_cast<named_type_t*>(resolved.get());
+        auto* ti = symtab_.lookup_type(nt->name);
+        if (ti != nullptr && ti->method_row != nullptr) {
+            auto* row = static_cast<row_type_t*>(ti->method_row.get());
+            if (auto found = row->find_entry(method)) {
+                return found;
+            }
+        }
+        // Unknown method — return fresh var (permissive for stdlib methods)
+        return env_.fresh_var();
+    }
+
+    if (resolved->kind() == type_kind::generic) {
+        // Methods on generic types (e.g. vector<int>.size()) — return fresh
+        return env_.fresh_var();
+    }
+
+    if (resolved->kind() == type_kind::type_var) {
+        return env_.fresh_var();
+    }
+
+    return env_.fresh_var();
+}
+
+// ── Expressions ──────────────────────────────────────────────────────────────
+
+void type_checker::visit(const identifier_node& node) {
+    auto* sym = symtab_.lookup(node.name);
+    if (sym != nullptr) {
+        set_type(node, sym->type);
+        return;
+    }
+    auto ft = symtab_.lookup_function(node.name);
+    if (ft != nullptr) {
+        set_type(node, ft);
+        return;
+    }
+    // Unknown symbol — assign fresh var (permissive: no stdlib)
+    set_type(node, env_.fresh_var());
+}
+
+void type_checker::visit(const number_node& node) {
+    // Number literals are int by default, but use a fresh var that will be
+    // constrained by context.  This allows `var x: double = 1;` to work.
+    set_type(node, env_.fresh_var());
+}
+
+void type_checker::visit(const string_node& node) { set_type(node, prim_string()); }
+
+void type_checker::visit(const binary_op_node& node) {
+    auto left = infer_expr(*node.left);
+    auto right = infer_expr(*node.right);
+
+    if (node.op == "&&" || node.op == "||") {
+        try_unify(node, left, prim_bool(), "logical operator lhs");
+        try_unify(node, right, prim_bool(), "logical operator rhs");
+        set_type(node, prim_bool());
+    } else if (node.op == "==" || node.op == "!=" || node.op == "<" || node.op == ">" ||
+               node.op == "<=" || node.op == ">=") {
+        try_unify(node, left, right, "comparison operands");
+        set_type(node, prim_bool());
+    } else {
+        // Arithmetic: +, -, *, /, %
+        try_unify(node, left, right, "arithmetic operands");
+        set_type(node, env_.find(left));
+    }
+}
+
+void type_checker::visit(const unary_op_node& node) {
+    auto operand = infer_expr(*node.operand);
+    if (node.op == "!") {
+        try_unify(node, operand, prim_bool(), "logical not");
+        set_type(node, prim_bool());
+    } else {
+        set_type(node, operand);
+    }
+}
+
+void type_checker::visit(const assign_node& node) {
+    auto lhs = infer_expr(*node.lhs);
+    auto rhs = infer_expr(*node.rhs);
+    try_unify(node, lhs, rhs, "assignment");
+    set_type(node, lhs);
+}
+
+void type_checker::visit(const call_node& node) {
+    auto ft = symtab_.lookup_function(node.name);
+    if (ft == nullptr) {
+        auto* sym = symtab_.lookup(node.name);
+        if (sym != nullptr) {
+            ft = sym->type;
+        }
+    }
+    if (ft == nullptr) {
+        // Unknown function — infer args, return fresh (permissive)
+        for (const auto& arg : node.args) {
+            infer_expr(*arg);
+        }
+        set_type(node, env_.fresh_var());
+        return;
+    }
+
+    auto inst = env_.instantiate(ft);
+    auto resolved = env_.find(inst);
+
+    if (resolved->kind() == type_kind::fun) {
+        auto* fun = static_cast<fun_type_t*>(resolved.get());
+        for (size_t i = 0; i < std::min(fun->params.size(), node.args.size()); ++i) {
+            auto arg_type = infer_expr(*node.args[i]);
+            try_unify(node, arg_type, fun->params[i],
+                      std::format("argument {} of '{}'", i + 1, node.name));
+        }
+        // Infer remaining args (if arity mismatch)
+        for (size_t i = fun->params.size(); i < node.args.size(); ++i) {
+            infer_expr(*node.args[i]);
+        }
+        set_type(node, fun->ret);
+    } else {
+        std::vector<type_ptr> param_types;
+        param_types.reserve(node.args.size());
+        for (const auto& arg : node.args) {
+            param_types.push_back(infer_expr(*arg));
+        }
+        auto ret = env_.fresh_var();
+        auto expected = std::make_shared<fun_type_t>(std::move(param_types), ret);
+        try_unify(node, resolved, expected, std::format("call to '{}'", node.name));
+        set_type(node, ret);
+    }
+}
+
+void type_checker::visit(const member_access_node& node) {
+    auto obj_type = infer_expr(*node.object);
+    auto field_type = lookup_field(node, std::move(obj_type), node.field);
+    set_type(node, std::move(field_type));
+}
+
+void type_checker::visit(const member_call_node& node) {
+    auto obj_type = infer_expr(*node.object);
+    auto method_type = lookup_method(node, obj_type, node.method);
+    auto resolved = env_.find(method_type);
+
+    if (resolved->kind() == type_kind::fun) {
+        auto* fun = static_cast<fun_type_t*>(resolved.get());
+        for (size_t i = 0; i < std::min(fun->params.size(), node.args.size()); ++i) {
+            auto arg_type = infer_expr(*node.args[i]);
+            try_unify(node, arg_type, fun->params[i],
+                      std::format("argument {} of method '{}'", i + 1, node.method));
+        }
+        for (size_t i = fun->params.size(); i < node.args.size(); ++i) {
+            infer_expr(*node.args[i]);
+        }
+        set_type(node, fun->ret);
+    } else {
+        // Unknown method — infer args, return fresh
+        for (const auto& arg : node.args) {
+            infer_expr(*arg);
+        }
+        set_type(node, env_.fresh_var());
+    }
+}
+
+void type_checker::visit(const qualified_call_node& node) {
+    auto ft = symtab_.lookup_function(node.qualifier + "::" + node.name);
+    if (ft == nullptr) {
+        auto* ti = symtab_.lookup_type(node.qualifier);
+        if (ti != nullptr && ti->method_row != nullptr) {
+            auto* row = static_cast<row_type_t*>(ti->method_row.get());
+            ft = row->find_entry(node.name);
+        }
+    }
+    if (ft == nullptr) {
+        // Unknown qualified function — infer args, return fresh
+        for (const auto& arg : node.args) {
+            infer_expr(*arg);
+        }
+        set_type(node, env_.fresh_var());
+        return;
+    }
+
+    auto inst = env_.instantiate(ft);
+    auto resolved = env_.find(inst);
+    if (resolved->kind() == type_kind::fun) {
+        auto* fun = static_cast<fun_type_t*>(resolved.get());
+        for (size_t i = 0; i < std::min(fun->params.size(), node.args.size()); ++i) {
+            auto arg_type = infer_expr(*node.args[i]);
+            try_unify(node, arg_type, fun->params[i],
+                      std::format("argument {} of '{}::{}'", i + 1, node.qualifier, node.name));
+        }
+        set_type(node, fun->ret);
+    } else {
+        set_type(node, env_.fresh_var());
+    }
+}
+
+void type_checker::visit(const index_node& node) {
+    auto base_type = infer_expr(*node.base);
+    auto index_type = infer_expr(*node.index);
+    try_unify(node, index_type, prim_int(), "index expression");
+
+    auto resolved = env_.find(base_type);
+    if (resolved->kind() == type_kind::generic) {
+        auto* gt = static_cast<generic_type_t*>(resolved.get());
+        if (!gt->args.empty()) {
+            set_type(node, gt->args[0]);
+            return;
+        }
+    }
+    auto elem = env_.fresh_var();
+    auto expected = std::make_shared<generic_type_t>("vector", std::vector<type_ptr>{elem});
+    try_unify(node, base_type, expected, "index base");
+    set_type(node, elem);
+}
+
+void type_checker::visit(const compound_assign_node& node) {
+    auto lhs = infer_expr(*node.lhs);
+    auto rhs = infer_expr(*node.rhs);
+    try_unify(node, lhs, rhs, "compound assignment");
+    set_type(node, lhs);
+}
+
+void type_checker::visit(const tuple_expr_node& node) {
+    std::vector<type_ptr> elem_types;
+    elem_types.reserve(node.elements.size());
+    for (const auto& e : node.elements) {
+        elem_types.push_back(infer_expr(*e));
+    }
+    set_type(node, std::make_shared<tuple_type_t>(std::move(elem_types)));
+}
+
+void type_checker::visit(const init_list_expr_node& node) {
+    auto elem = env_.fresh_var();
+    for (const auto& a : node.args) {
+        auto arg_type = infer_expr(*a);
+        try_unify(node, arg_type, elem, "init list element");
+    }
+    set_type(node, std::make_shared<generic_type_t>("vector", std::vector<type_ptr>{elem}));
+}
+
+// ── Statements ───────────────────────────────────────────────────────────────
+
+void type_checker::visit(const expr_stmt_node& node) { node.expr->accept(*this); }
+
+void type_checker::visit(const var_decl_node& node) {
+    type_ptr var_type;
+    if (!node.type.empty()) {
+        var_type = parse_type_string(node.type);
+    } else {
+        var_type = env_.fresh_var();
+    }
+
+    if (node.init != nullptr) {
+        auto init_type = infer_expr(*node.init);
+        try_unify(node, var_type, init_type, "variable declaration");
+    }
+
+    symtab_.bind(node.name, {node.name, var_type, false, &node});
+}
+
+void type_checker::visit(const tuple_var_decl_node& node) {
+    auto init_type = infer_expr(*node.init);
+
+    std::vector<type_ptr> elem_types;
+    elem_types.reserve(node.names.size());
+    for (size_t i = 0; i < node.names.size(); ++i) {
+        elem_types.push_back(env_.fresh_var());
+    }
+    auto expected = std::make_shared<tuple_type_t>(elem_types);
+    try_unify(node, init_type, expected, "tuple variable declaration");
+
+    for (size_t i = 0; i < node.names.size(); ++i) {
+        symtab_.bind(node.names[i], {node.names[i], elem_types[i], false, &node});
+    }
+}
+
+void type_checker::visit(const tuple_assign_stmt_node& node) {
+    auto rhs_type = infer_expr(*node.rhs);
+
+    std::vector<type_ptr> lhs_types;
+    lhs_types.reserve(node.lhs_exprs.size());
+    for (const auto& lhs : node.lhs_exprs) {
+        lhs_types.push_back(infer_expr(*lhs));
+    }
+
+    auto resolved = env_.find(rhs_type);
+    if (resolved->kind() == type_kind::tuple) {
+        auto* tup = static_cast<tuple_type_t*>(resolved.get());
+        for (size_t i = 0; i < std::min(tup->elements.size(), lhs_types.size()); ++i) {
+            try_unify(node, lhs_types[i], tup->elements[i], "tuple assignment");
+        }
+    } else {
+        auto expected = std::make_shared<tuple_type_t>(lhs_types);
+        try_unify(node, rhs_type, expected, "tuple assignment");
+    }
+}
+
+void type_checker::visit(const return_stmt_node& node) {
+    if (node.value != nullptr) {
+        auto val_type = infer_expr(*node.value);
+        if (current_return_type_ != nullptr) {
+            try_unify(node, val_type, current_return_type_, "return statement");
+        }
+    }
+}
+
+void type_checker::visit(const for_stmt_node& node) {
+    symtab_.push_scope();
+    node.init->accept(*this);
+    auto cond_type = infer_expr(*node.condition);
+    try_unify(node, cond_type, prim_bool(), "for loop condition");
+    node.increment->accept(*this);
+    node.body->accept(*this);
+    symtab_.pop_scope();
+}
+
+void type_checker::visit(const for_range_stmt_node& node) {
+    symtab_.push_scope();
+    auto range_type = infer_expr(*node.range);
+    auto elem_type = env_.fresh_var();
+    symtab_.bind(node.var_name, {node.var_name, elem_type, false, &node});
+    node.body->accept(*this);
+    symtab_.pop_scope();
+}
+
+void type_checker::visit(const compound_stmt_node& node) {
+    symtab_.push_scope();
+    for (const auto& stmt : node.statements) {
+        stmt->accept(*this);
+    }
+    symtab_.pop_scope();
+}
+
+void type_checker::visit(const if_stmt_node& node) {
+    auto cond_type = infer_expr(*node.condition);
+    try_unify(node, cond_type, prim_bool(), "if condition");
+    node.then_body->accept(*this);
+    if (node.else_body != nullptr) {
+        node.else_body->accept(*this);
+    }
+}
+
+void type_checker::visit(const continue_stmt_node& /*node*/) {}
+void type_checker::visit(const break_stmt_node& /*node*/) {}
+
+// ── Declarations ─────────────────────────────────────────────────────────────
+
+void type_checker::visit(const param_node& /*node*/) {}
+
+void type_checker::visit(const func_decl_node& node) {
+    auto ft = symtab_.lookup_function(node.name);
+    if (ft == nullptr) {
+        return;
+    }
+
+    auto resolved = env_.find(ft);
+    if (resolved->kind() != type_kind::fun) {
+        return;
+    }
+    auto* fun = static_cast<fun_type_t*>(resolved.get());
+
+    env_.enter_level();
+    symtab_.push_scope();
+
+    for (size_t i = 0; i < node.params.size(); ++i) {
+        symtab_.bind(node.params[i]->name, {node.params[i]->name, fun->params[i],
+                                            node.params[i]->is_ref, node.params[i].get()});
+    }
+
+    auto prev_return = current_return_type_;
+    current_return_type_ = fun->ret;
+
+    node.body->accept(*this);
+
+    current_return_type_ = prev_return;
+    symtab_.pop_scope();
+    env_.leave_level();
+
+    env_.generalize(ft, env_.current_level());
+}
+
+void type_checker::visit(const method_decl_node& node) {
+    auto* ti = symtab_.lookup_type(node.type_name);
+    if (ti == nullptr) {
+        return;
+    }
+
+    type_ptr method_type;
+    if (ti->method_row != nullptr) {
+        auto* mr = static_cast<row_type_t*>(ti->method_row.get());
+        method_type = mr->find_entry(node.name);
+    }
+    if (method_type == nullptr) {
+        return;
+    }
+
+    auto resolved = env_.find(method_type);
+    if (resolved->kind() != type_kind::fun) {
+        return;
+    }
+    auto* fun = static_cast<fun_type_t*>(resolved.get());
+
+    env_.enter_level();
+    symtab_.push_scope();
+
+    // Bind struct fields in scope for implicit field access
+    if (ti->field_row != nullptr) {
+        auto* fr = static_cast<row_type_t*>(ti->field_row.get());
+        for (const auto& e : fr->entries) {
+            symtab_.bind(e.label, {e.label, e.type, false, nullptr});
+        }
+    }
+
+    for (size_t i = 0; i < node.params.size(); ++i) {
+        symtab_.bind(node.params[i]->name, {node.params[i]->name, fun->params[i],
+                                            node.params[i]->is_ref, node.params[i].get()});
+    }
+
+    auto prev_return = current_return_type_;
+    current_return_type_ = fun->ret;
+
+    node.body->accept(*this);
+
+    current_return_type_ = prev_return;
+    symtab_.pop_scope();
+    env_.leave_level();
+}
+
+void type_checker::visit(const type_decl_node& /*node*/) {}
+void type_checker::visit(const struct_field_node& /*node*/) {}
+void type_checker::visit(const struct_type_node& /*node*/) {}
+void type_checker::visit(const interface_type_node& /*node*/) {}
+void type_checker::visit(const interface_method_node& /*node*/) {}
+
+void type_checker::visit(const program_node& node) {
+    for (const auto& decl : node.declarations) {
+        decl->accept(*this);
+    }
+}

--- a/src/type_checker.h
+++ b/src/type_checker.h
@@ -1,0 +1,81 @@
+#ifndef TYPE_CHECKER_H
+#define TYPE_CHECKER_H
+
+#include <unordered_map>
+
+#include "diagnostics.h"
+#include "symbol_table.h"
+#include "types.h"
+#include "unify.h"
+#include "visitor.h"
+
+class ast_node;
+
+// Type inference visitor.  Walks the AST after name resolution, infers types
+// for expressions, and checks type consistency.  Expression types are stored
+// in a side table to avoid modifying AST node classes.
+class type_checker : public visitor {
+public:
+    type_checker(symbol_table& symtab, type_env& env, diagnostics& diag)
+        : symtab_(symtab), env_(env), diag_(diag) {}
+
+    // Side table: maps AST nodes to their inferred types.
+    [[nodiscard]] type_ptr type_of(const ast_node* node) const;
+
+    // visitor interface
+    void visit(const class identifier_node&) override;
+    void visit(const class number_node&) override;
+    void visit(const class string_node&) override;
+    void visit(const class binary_op_node&) override;
+    void visit(const class unary_op_node&) override;
+    void visit(const class assign_node&) override;
+    void visit(const class expr_stmt_node&) override;
+    void visit(const class param_node&) override;
+    void visit(const class var_decl_node&) override;
+    void visit(const class return_stmt_node&) override;
+    void visit(const class for_stmt_node&) override;
+    void visit(const class compound_stmt_node&) override;
+    void visit(const class func_decl_node&) override;
+    void visit(const class struct_field_node&) override;
+    void visit(const class struct_type_node&) override;
+    void visit(const class method_decl_node&) override;
+    void visit(const class type_decl_node&) override;
+    void visit(const class interface_type_node&) override;
+    void visit(const class interface_method_node&) override;
+    void visit(const class member_call_node&) override;
+    void visit(const class member_access_node&) override;
+    void visit(const class qualified_call_node&) override;
+    void visit(const class call_node&) override;
+    void visit(const class index_node&) override;
+    void visit(const class compound_assign_node&) override;
+    void visit(const class if_stmt_node&) override;
+    void visit(const class tuple_expr_node&) override;
+    void visit(const class tuple_var_decl_node&) override;
+    void visit(const class tuple_assign_stmt_node&) override;
+    void visit(const class for_range_stmt_node&) override;
+    void visit(const class continue_stmt_node&) override;
+    void visit(const class break_stmt_node&) override;
+    void visit(const class init_list_expr_node&) override;
+    void visit(const class program_node&) override;
+
+private:
+    symbol_table& symtab_;
+    type_env& env_;
+    diagnostics& diag_;
+
+    // Expression type side table
+    std::unordered_map<const ast_node*, type_ptr> type_map_;
+
+    // Current function's return type (for return statement checking)
+    type_ptr current_return_type_;
+
+    void set_type(const ast_node& node, type_ptr t);
+    type_ptr infer_expr(const class expr_node& node);
+    void try_unify(const ast_node& node, type_ptr a, type_ptr b, const std::string& context);
+
+    // Row-based member lookup helpers
+    type_ptr lookup_field(const ast_node& node, type_ptr obj_type, const std::string& field);
+    type_ptr lookup_method(const ast_node& node, type_ptr obj_type, const std::string& method);
+};
+
+#endif  // TYPE_CHECKER_H

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,0 +1,183 @@
+#include "types.h"
+
+#include <format>
+#include <stdexcept>
+
+// ── Primitive singletons ─────────────────────────────────────────────────────
+
+static type_ptr make_prim(prim_kind k) {
+    static auto i = std::make_shared<prim_type_t>(prim_kind::int_t);
+    static auto b = std::make_shared<prim_type_t>(prim_kind::bool_t);
+    static auto by = std::make_shared<prim_type_t>(prim_kind::byte_t);
+    static auto f = std::make_shared<prim_type_t>(prim_kind::float_t);
+    static auto d = std::make_shared<prim_type_t>(prim_kind::double_t);
+    static auto c = std::make_shared<prim_type_t>(prim_kind::char_t);
+    static auto s = std::make_shared<prim_type_t>(prim_kind::string_t);
+    switch (k) {
+        case prim_kind::int_t:
+            return i;
+        case prim_kind::bool_t:
+            return b;
+        case prim_kind::byte_t:
+            return by;
+        case prim_kind::float_t:
+            return f;
+        case prim_kind::double_t:
+            return d;
+        case prim_kind::char_t:
+            return c;
+        case prim_kind::string_t:
+            return s;
+    }
+    __builtin_unreachable();
+}
+
+type_ptr prim_int() { return make_prim(prim_kind::int_t); }
+type_ptr prim_bool() { return make_prim(prim_kind::bool_t); }
+type_ptr prim_byte() { return make_prim(prim_kind::byte_t); }
+type_ptr prim_float() { return make_prim(prim_kind::float_t); }
+type_ptr prim_double() { return make_prim(prim_kind::double_t); }
+type_ptr prim_char() { return make_prim(prim_kind::char_t); }
+type_ptr prim_string() { return make_prim(prim_kind::string_t); }
+
+// ── to_string implementations ────────────────────────────────────────────────
+
+std::string prim_type_t::to_string() const {
+    switch (prim) {
+        case prim_kind::int_t:
+            return "int";
+        case prim_kind::bool_t:
+            return "bool";
+        case prim_kind::byte_t:
+            return "byte";
+        case prim_kind::float_t:
+            return "float";
+        case prim_kind::double_t:
+            return "double";
+        case prim_kind::char_t:
+            return "char";
+        case prim_kind::string_t:
+            return "string";
+    }
+    __builtin_unreachable();
+}
+
+std::string sized_int_type_t::to_string() const {
+    return is_unsigned ? std::format("integer<+{}>", bits) : std::format("integer<{}>", bits);
+}
+
+std::string type_var_t::to_string() const {
+    if (bound) return bound->to_string();
+    return std::format("'{}", id);
+}
+
+std::string fun_type_t::to_string() const {
+    std::string result = "(";
+    for (bool first = true; const auto& p : params) {
+        if (!first) result += ", ";
+        result += p->to_string();
+        first = false;
+    }
+    result += ") -> " + ret->to_string();
+    return result;
+}
+
+std::string tuple_type_t::to_string() const {
+    std::string result = "(";
+    for (bool first = true; const auto& e : elements) {
+        if (!first) result += ", ";
+        result += e->to_string();
+        first = false;
+    }
+    result += ")";
+    return result;
+}
+
+std::string generic_type_t::to_string() const {
+    std::string result = name + "<";
+    for (bool first = true; const auto& a : args) {
+        if (!first) result += ", ";
+        result += a->to_string();
+        first = false;
+    }
+    result += ">";
+    return result;
+}
+
+std::string row_type_t::to_string() const {
+    std::string result = "{";
+    for (bool first = true; const auto& e : entries) {
+        if (!first) result += ", ";
+        result += e.label + ": " + e.type->to_string();
+        first = false;
+    }
+    if (tail) {
+        result += " | " + tail->to_string();
+    }
+    result += "}";
+    return result;
+}
+
+std::string named_type_t::to_string() const { return name; }
+
+type_ptr row_type_t::find_entry(const std::string& label) const {
+    for (const auto& e : entries) {
+        if (e.label == label) {
+            return e.type;
+        }
+    }
+    return nullptr;
+}
+
+// ── parse_type_string ────────────────────────────────────────────────────────
+
+// Parse the opaque type strings stored in AST nodes into the type IR.
+// Grammar is restricted: base_type | IDENTIFIER | IDENTIFIER<inner> |
+//                        integer<N> | integer<+N>
+type_ptr parse_type_string(const std::string& s) {
+    if (s.empty()) return nullptr;
+
+    // Primitive types
+    if (s == "int") return prim_int();
+    if (s == "bool") return prim_bool();
+    if (s == "byte") return prim_byte();
+    if (s == "float") return prim_float();
+    if (s == "double") return prim_double();
+    if (s == "char") return prim_char();
+    if (s == "string") return prim_string();
+
+    // Check for generic/sized-int: look for '<'
+    auto lt = s.find('<');
+    if (lt != std::string::npos) {
+        auto gt = s.rfind('>');
+        if (gt == std::string::npos || gt <= lt) {
+            throw std::runtime_error(std::format("malformed type: '{}'", s));
+        }
+        std::string outer = s.substr(0, lt);
+        std::string inner = s.substr(lt + 1, gt - lt - 1);
+
+        // Sized integer: integer<N> or integer<+N>
+        if (outer == "integer") {
+            bool is_unsigned = false;
+            std::string num_str = inner;
+            if (!inner.empty() && inner[0] == '+') {
+                is_unsigned = true;
+                num_str = inner.substr(1);
+            }
+            int bits = std::stoi(num_str);
+            return std::make_shared<sized_int_type_t>(bits, is_unsigned);
+        }
+
+        // Generic type: name<inner_type>
+        type_ptr inner_type = parse_type_string(inner);
+        if (!inner_type) {
+            throw std::runtime_error(std::format("malformed generic type arg: '{}'", inner));
+        }
+        std::vector<type_ptr> args;
+        args.push_back(std::move(inner_type));
+        return std::make_shared<generic_type_t>(std::move(outer), std::move(args));
+    }
+
+    // Named type (user-defined struct/interface)
+    return std::make_shared<named_type_t>(s);
+}

--- a/src/types.h
+++ b/src/types.h
@@ -1,0 +1,150 @@
+#ifndef TYPES_H
+#define TYPES_H
+
+#include <memory>
+#include <string>
+#include <vector>
+
+// Forward declaration
+class type_t;
+using type_ptr = std::shared_ptr<type_t>;
+
+// ── Type IR hierarchy ────────────────────────────────────────────────────────
+
+enum class type_kind {
+    prim,
+    sized_int,
+    type_var,
+    fun,
+    tuple,
+    generic,
+    row,
+    named,
+};
+
+class type_t {
+public:
+    virtual ~type_t() = default;
+    [[nodiscard]] virtual type_kind kind() const noexcept = 0;
+    [[nodiscard]] virtual std::string to_string() const = 0;
+};
+
+// ── Primitive types (singletons) ─────────────────────────────────────────────
+
+enum class prim_kind { int_t, bool_t, byte_t, float_t, double_t, char_t, string_t };
+
+class prim_type_t : public type_t {
+public:
+    prim_kind prim;
+    explicit prim_type_t(prim_kind p) noexcept : prim(p) {}
+    [[nodiscard]] type_kind kind() const noexcept override { return type_kind::prim; }
+    [[nodiscard]] std::string to_string() const override;
+};
+
+// Singleton accessors for primitive types.
+type_ptr prim_int();
+type_ptr prim_bool();
+type_ptr prim_byte();
+type_ptr prim_float();
+type_ptr prim_double();
+type_ptr prim_char();
+type_ptr prim_string();
+
+// ── Sized integer: integer<N> or integer<+N> ────────────────────────────────
+
+class sized_int_type_t : public type_t {
+public:
+    int bits;
+    bool is_unsigned;
+    sized_int_type_t(int b, bool u) noexcept : bits(b), is_unsigned(u) {}
+    [[nodiscard]] type_kind kind() const noexcept override { return type_kind::sized_int; }
+    [[nodiscard]] std::string to_string() const override;
+};
+
+// ── Type variable (unification) ─────────────────────────────────────────────
+
+class type_var_t : public type_t {
+public:
+    int id;
+    int level;
+    type_ptr bound;  // nullptr = free
+
+    type_var_t(int id, int lvl) noexcept : id(id), level(lvl) {}
+    [[nodiscard]] type_kind kind() const noexcept override { return type_kind::type_var; }
+    [[nodiscard]] std::string to_string() const override;
+};
+
+// ── Function type: (T1, T2, ...) -> T_ret ───────────────────────────────────
+
+class fun_type_t : public type_t {
+public:
+    std::vector<type_ptr> params;
+    type_ptr ret;
+
+    fun_type_t(std::vector<type_ptr> p, type_ptr r) : params(std::move(p)), ret(std::move(r)) {}
+    [[nodiscard]] type_kind kind() const noexcept override { return type_kind::fun; }
+    [[nodiscard]] std::string to_string() const override;
+};
+
+// ── Tuple type: (T1, T2, ...) ───────────────────────────────────────────────
+
+class tuple_type_t : public type_t {
+public:
+    std::vector<type_ptr> elements;
+
+    explicit tuple_type_t(std::vector<type_ptr> elts) : elements(std::move(elts)) {}
+    [[nodiscard]] type_kind kind() const noexcept override { return type_kind::tuple; }
+    [[nodiscard]] std::string to_string() const override;
+};
+
+// ── Generic type: name<T1, T2, ...> (e.g. vector<int>) ─────────────────────
+
+class generic_type_t : public type_t {
+public:
+    std::string name;
+    std::vector<type_ptr> args;
+
+    generic_type_t(std::string n, std::vector<type_ptr> a)
+        : name(std::move(n)), args(std::move(a)) {}
+    [[nodiscard]] type_kind kind() const noexcept override { return type_kind::generic; }
+    [[nodiscard]] std::string to_string() const override;
+};
+
+// ── Row type: { label1: T1, ... | tail } ────────────────────────────────────
+
+struct row_entry {
+    std::string label;
+    type_ptr type;
+};
+
+class row_type_t : public type_t {
+public:
+    std::vector<row_entry> entries;
+    type_ptr tail;  // nullptr = closed, type_var = open (ρ)
+
+    row_type_t(std::vector<row_entry> e, type_ptr t) : entries(std::move(e)), tail(std::move(t)) {}
+    [[nodiscard]] type_kind kind() const noexcept override { return type_kind::row; }
+    [[nodiscard]] std::string to_string() const override;
+
+    // Find an entry by label.  Returns nullptr if not found.
+    [[nodiscard]] type_ptr find_entry(const std::string& label) const;
+};
+
+// ── Named type: reference to a declared struct/interface ────────────────────
+
+class named_type_t : public type_t {
+public:
+    std::string name;
+
+    explicit named_type_t(std::string n) : name(std::move(n)) {}
+    [[nodiscard]] type_kind kind() const noexcept override { return type_kind::named; }
+    [[nodiscard]] std::string to_string() const override;
+};
+
+// ── Parse helper ─────────────────────────────────────────────────────────────
+
+// Convert opaque type strings (as stored in AST nodes) to type_ptr.
+// Returns nullptr for empty strings (un-annotated / inferred).
+type_ptr parse_type_string(const std::string& s);
+
+#endif  // TYPES_H

--- a/src/unify.cpp
+++ b/src/unify.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <format>
+#include <functional>
 #include <unordered_map>
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/src/unify.cpp
+++ b/src/unify.cpp
@@ -1,0 +1,395 @@
+#include "unify.h"
+
+#include <algorithm>
+#include <format>
+#include <unordered_map>
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+type_ptr type_env::fresh_var() { return std::make_shared<type_var_t>(next_id_++, current_level_); }
+
+type_ptr type_env::find(type_ptr t) const {
+    // Path compression: flatten union-find chains so future lookups are O(1).
+    while (t->kind() == type_kind::type_var) {
+        auto* tv = static_cast<type_var_t*>(t.get());
+        if (!tv->bound) {
+            break;
+        }
+        // Skip one level (path splitting)
+        if (tv->bound->kind() == type_kind::type_var) {
+            auto* next = static_cast<type_var_t*>(tv->bound.get());
+            if (next->bound) {
+                tv->bound = next->bound;
+            }
+        }
+        t = tv->bound;
+    }
+    return t;
+}
+
+bool type_env::occurs_in(int var_id, const type_ptr& t) const {
+    auto resolved = find(t);
+    switch (resolved->kind()) {
+        case type_kind::type_var: {
+            auto* tv = static_cast<type_var_t*>(resolved.get());
+            return tv->id == var_id;
+        }
+        case type_kind::fun: {
+            auto* ft = static_cast<fun_type_t*>(resolved.get());
+            for (const auto& p : ft->params) {
+                if (occurs_in(var_id, p)) {
+                    return true;
+                }
+            }
+            return occurs_in(var_id, ft->ret);
+        }
+        case type_kind::tuple: {
+            auto* tt = static_cast<tuple_type_t*>(resolved.get());
+            for (const auto& e : tt->elements) {
+                if (occurs_in(var_id, e)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        case type_kind::generic: {
+            auto* gt = static_cast<generic_type_t*>(resolved.get());
+            for (const auto& a : gt->args) {
+                if (occurs_in(var_id, a)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        case type_kind::row: {
+            auto* rt = static_cast<row_type_t*>(resolved.get());
+            for (const auto& e : rt->entries) {
+                if (occurs_in(var_id, e.type)) {
+                    return true;
+                }
+            }
+            if (rt->tail) {
+                return occurs_in(var_id, rt->tail);
+            }
+            return false;
+        }
+        case type_kind::prim:
+        case type_kind::sized_int:
+        case type_kind::named:
+            return false;
+    }
+    __builtin_unreachable();
+}
+
+// ── Unification ──────────────────────────────────────────────────────────────
+
+void type_env::unify(type_ptr a, type_ptr b) {
+    a = find(a);
+    b = find(b);
+
+    if (a.get() == b.get()) {
+        return;
+    }
+
+    // type_var binds
+    if (a->kind() == type_kind::type_var) {
+        auto* tv = static_cast<type_var_t*>(a.get());
+        if (occurs_in(tv->id, b)) {
+            throw type_error(
+                std::format("infinite type: '{}' occurs in '{}'", a->to_string(), b->to_string()));
+        }
+        tv->bound = b;
+        return;
+    }
+    if (b->kind() == type_kind::type_var) {
+        auto* tv = static_cast<type_var_t*>(b.get());
+        if (occurs_in(tv->id, a)) {
+            throw type_error(
+                std::format("infinite type: '{}' occurs in '{}'", b->to_string(), a->to_string()));
+        }
+        tv->bound = a;
+        return;
+    }
+
+    // Primitives
+    if (a->kind() == type_kind::prim && b->kind() == type_kind::prim) {
+        auto* pa = static_cast<prim_type_t*>(a.get());
+        auto* pb = static_cast<prim_type_t*>(b.get());
+        if (pa->prim != pb->prim) {
+            throw type_error(
+                std::format("cannot unify '{}' with '{}'", a->to_string(), b->to_string()));
+        }
+        return;
+    }
+
+    // Sized integers
+    if (a->kind() == type_kind::sized_int && b->kind() == type_kind::sized_int) {
+        auto* sa = static_cast<sized_int_type_t*>(a.get());
+        auto* sb = static_cast<sized_int_type_t*>(b.get());
+        if (sa->bits != sb->bits || sa->is_unsigned != sb->is_unsigned) {
+            throw type_error(
+                std::format("cannot unify '{}' with '{}'", a->to_string(), b->to_string()));
+        }
+        return;
+    }
+
+    // Function types
+    if (a->kind() == type_kind::fun && b->kind() == type_kind::fun) {
+        auto* fa = static_cast<fun_type_t*>(a.get());
+        auto* fb = static_cast<fun_type_t*>(b.get());
+        if (fa->params.size() != fb->params.size()) {
+            throw type_error(std::format("function arity mismatch: {} vs {} params",
+                                         fa->params.size(), fb->params.size()));
+        }
+        for (size_t i = 0; i < fa->params.size(); ++i) {
+            unify(fa->params[i], fb->params[i]);
+        }
+        unify(fa->ret, fb->ret);
+        return;
+    }
+
+    // Tuple types
+    if (a->kind() == type_kind::tuple && b->kind() == type_kind::tuple) {
+        auto* ta = static_cast<tuple_type_t*>(a.get());
+        auto* tb = static_cast<tuple_type_t*>(b.get());
+        if (ta->elements.size() != tb->elements.size()) {
+            throw type_error(std::format("tuple size mismatch: {} vs {} elements",
+                                         ta->elements.size(), tb->elements.size()));
+        }
+        for (size_t i = 0; i < ta->elements.size(); ++i) {
+            unify(ta->elements[i], tb->elements[i]);
+        }
+        return;
+    }
+
+    // Generic types
+    if (a->kind() == type_kind::generic && b->kind() == type_kind::generic) {
+        auto* ga = static_cast<generic_type_t*>(a.get());
+        auto* gb = static_cast<generic_type_t*>(b.get());
+        if (ga->name != gb->name || ga->args.size() != gb->args.size()) {
+            throw type_error(
+                std::format("cannot unify '{}' with '{}'", a->to_string(), b->to_string()));
+        }
+        for (size_t i = 0; i < ga->args.size(); ++i) {
+            unify(ga->args[i], gb->args[i]);
+        }
+        return;
+    }
+
+    // Named types — same name means same type
+    if (a->kind() == type_kind::named && b->kind() == type_kind::named) {
+        auto* na = static_cast<named_type_t*>(a.get());
+        auto* nb = static_cast<named_type_t*>(b.get());
+        if (na->name == nb->name) {
+            return;
+        }
+    }
+
+    // Row types
+    if (a->kind() == type_kind::row && b->kind() == type_kind::row) {
+        unify_rows(a, b);
+        return;
+    }
+
+    throw type_error(std::format("cannot unify '{}' with '{}'", a->to_string(), b->to_string()));
+}
+
+// ── Rémy-style row unification ───────────────────────────────────────────────
+
+void type_env::unify_rows(const type_ptr& a, const type_ptr& b) {
+    auto* ra = static_cast<row_type_t*>(a.get());
+    auto* rb = static_cast<row_type_t*>(b.get());
+
+    // Build label maps
+    std::unordered_map<std::string, type_ptr> map_a;
+    for (const auto& e : ra->entries) {
+        map_a[e.label] = e.type;
+    }
+    std::unordered_map<std::string, type_ptr> map_b;
+    for (const auto& e : rb->entries) {
+        map_b[e.label] = e.type;
+    }
+
+    // Unify shared labels
+    for (const auto& [label, type_a] : map_a) {
+        if (auto it = map_b.find(label); it != map_b.end()) {
+            unify(type_a, it->second);
+        }
+    }
+
+    // Compute extra labels on each side
+    std::vector<row_entry> only_a;
+    for (const auto& e : ra->entries) {
+        if (map_b.find(e.label) == map_b.end()) {
+            only_a.push_back(e);
+        }
+    }
+    std::vector<row_entry> only_b;
+    for (const auto& e : rb->entries) {
+        if (map_a.find(e.label) == map_a.end()) {
+            only_b.push_back(e);
+        }
+    }
+
+    auto tail_a = ra->tail ? find(ra->tail) : nullptr;
+    auto tail_b = rb->tail ? find(rb->tail) : nullptr;
+    bool a_open = tail_a && tail_a->kind() == type_kind::type_var;
+    bool b_open = tail_b && tail_b->kind() == type_kind::type_var;
+
+    if (!a_open && !b_open) {
+        // Both closed: extra labels on either side is an error
+        if (!only_a.empty() || !only_b.empty()) {
+            std::string missing;
+            for (const auto& e : only_a) {
+                if (!missing.empty()) {
+                    missing += ", ";
+                }
+                missing += e.label;
+            }
+            for (const auto& e : only_b) {
+                if (!missing.empty()) {
+                    missing += ", ";
+                }
+                missing += e.label;
+            }
+            throw type_error(std::format("row mismatch: extra labels {}", missing));
+        }
+    } else if (a_open && !b_open) {
+        // a is open, b is closed: a's tail binds to b's extras
+        if (!only_a.empty()) {
+            throw type_error("closed row missing labels from open row");
+        }
+        auto new_row = std::make_shared<row_type_t>(std::move(only_b), nullptr);
+        unify(tail_a, new_row);
+    } else if (!a_open && b_open) {
+        // b is open, a is closed: b's tail binds to a's extras
+        if (!only_b.empty()) {
+            throw type_error("closed row missing labels from open row");
+        }
+        auto new_row = std::make_shared<row_type_t>(std::move(only_a), nullptr);
+        unify(tail_b, new_row);
+    } else {
+        // Both open: fresh ρ, bind both tails to extras + ρ
+        auto fresh = fresh_var();
+        auto row_for_a = std::make_shared<row_type_t>(std::move(only_b), fresh);
+        auto row_for_b = std::make_shared<row_type_t>(std::move(only_a), fresh);
+        unify(tail_a, row_for_a);
+        unify(tail_b, row_for_b);
+    }
+}
+
+// ── Generalize / Instantiate ─────────────────────────────────────────────────
+
+// Generalize: mark free type vars at level > `level` as generic (level = -1).
+type_ptr type_env::generalize(type_ptr t, int level) {
+    t = find(t);
+    switch (t->kind()) {
+        case type_kind::type_var: {
+            auto* tv = static_cast<type_var_t*>(t.get());
+            if (tv->level > level) {
+                tv->level = -1;  // Mark as generic/quantified
+            }
+            return t;
+        }
+        case type_kind::fun: {
+            auto* ft = static_cast<fun_type_t*>(t.get());
+            for (auto& p : ft->params) {
+                p = generalize(p, level);
+            }
+            ft->ret = generalize(ft->ret, level);
+            return t;
+        }
+        case type_kind::tuple: {
+            auto* tt = static_cast<tuple_type_t*>(t.get());
+            for (auto& e : tt->elements) {
+                e = generalize(e, level);
+            }
+            return t;
+        }
+        case type_kind::generic: {
+            auto* gt = static_cast<generic_type_t*>(t.get());
+            for (auto& a : gt->args) {
+                a = generalize(a, level);
+            }
+            return t;
+        }
+        case type_kind::row: {
+            auto* rt = static_cast<row_type_t*>(t.get());
+            for (auto& e : rt->entries) {
+                e.type = generalize(e.type, level);
+            }
+            if (rt->tail) {
+                rt->tail = generalize(rt->tail, level);
+            }
+            return t;
+        }
+        default:
+            return t;
+    }
+}
+
+// Instantiate: replace generic type vars (level == -1) with fresh vars.
+type_ptr type_env::instantiate(type_ptr scheme) {
+    std::unordered_map<int, type_ptr> mapping;
+
+    std::function<type_ptr(type_ptr)> inst = [&](type_ptr t) -> type_ptr {
+        t = find(t);
+        switch (t->kind()) {
+            case type_kind::type_var: {
+                auto* tv = static_cast<type_var_t*>(t.get());
+                if (tv->level == -1) {
+                    auto it = mapping.find(tv->id);
+                    if (it == mapping.end()) {
+                        auto fv = fresh_var();
+                        mapping[tv->id] = fv;
+                        return fv;
+                    }
+                    return it->second;
+                }
+                return t;
+            }
+            case type_kind::fun: {
+                auto* ft = static_cast<fun_type_t*>(t.get());
+                std::vector<type_ptr> params;
+                params.reserve(ft->params.size());
+                for (const auto& p : ft->params) {
+                    params.push_back(inst(p));
+                }
+                auto ret = inst(ft->ret);
+                return std::make_shared<fun_type_t>(std::move(params), std::move(ret));
+            }
+            case type_kind::tuple: {
+                auto* tt = static_cast<tuple_type_t*>(t.get());
+                std::vector<type_ptr> elts;
+                elts.reserve(tt->elements.size());
+                for (const auto& e : tt->elements) {
+                    elts.push_back(inst(e));
+                }
+                return std::make_shared<tuple_type_t>(std::move(elts));
+            }
+            case type_kind::generic: {
+                auto* gt = static_cast<generic_type_t*>(t.get());
+                std::vector<type_ptr> args;
+                args.reserve(gt->args.size());
+                for (const auto& a : gt->args) {
+                    args.push_back(inst(a));
+                }
+                return std::make_shared<generic_type_t>(gt->name, std::move(args));
+            }
+            case type_kind::row: {
+                auto* rt = static_cast<row_type_t*>(t.get());
+                std::vector<row_entry> entries;
+                entries.reserve(rt->entries.size());
+                for (const auto& e : rt->entries) {
+                    entries.push_back({e.label, inst(e.type)});
+                }
+                auto tail = rt->tail ? inst(rt->tail) : nullptr;
+                return std::make_shared<row_type_t>(std::move(entries), std::move(tail));
+            }
+            default:
+                return t;
+        }
+    };
+
+    return inst(std::move(scheme));
+}

--- a/src/unify.h
+++ b/src/unify.h
@@ -1,0 +1,49 @@
+#ifndef UNIFY_H
+#define UNIFY_H
+
+#include <stdexcept>
+#include <string>
+
+#include "types.h"
+
+// ── Type error ───────────────────────────────────────────────────────────────
+
+class type_error : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+// ── Type environment (unification engine) ────────────────────────────────────
+
+class type_env {
+public:
+    // Create a fresh type variable at the current level.
+    type_ptr fresh_var();
+
+    // Follow union-find chains to the representative type.
+    type_ptr find(type_ptr t) const;
+
+    // Unify two types.  Throws type_error on failure.
+    void unify(type_ptr a, type_ptr b);
+
+    // Generalize: replace free type vars at level > `level` with quantified
+    // vars.  Returns a polymorphic type scheme.
+    type_ptr generalize(type_ptr t, int level);
+
+    // Instantiate: replace quantified vars with fresh type vars.
+    type_ptr instantiate(type_ptr scheme);
+
+    // Scope level management for let-polymorphism.
+    void enter_level() { ++current_level_; }
+    void leave_level() { --current_level_; }
+    [[nodiscard]] int current_level() const noexcept { return current_level_; }
+
+private:
+    int next_id_ = 0;
+    int current_level_ = 0;
+
+    bool occurs_in(int var_id, const type_ptr& t) const;
+    void unify_rows(const type_ptr& a, const type_ptr& b);
+};
+
+#endif  // UNIFY_H

--- a/tests/fixtures/invalid/duplicate_func.dub
+++ b/tests/fixtures/invalid/duplicate_func.dub
@@ -1,0 +1,8 @@
+// Two functions with the same name — resolver should error.
+fun add(a: int, b: int) -> int {
+    return (a + b);
+}
+
+fun add(x: int) -> int {
+    return x;
+}

--- a/tests/fixtures/invalid/duplicate_type.dub
+++ b/tests/fixtures/invalid/duplicate_type.dub
@@ -1,0 +1,11 @@
+// Two types with the same name — resolver should error.
+type point = struct {
+    x: int;
+    y: int;
+}
+
+type point = struct {
+    r: float;
+    g: float;
+    b: float;
+}

--- a/tests/fixtures/valid/semantic_basic.dub
+++ b/tests/fixtures/valid/semantic_basic.dub
@@ -1,0 +1,9 @@
+// Basic type inference: annotated params, return, and variable binding.
+fun add(a: int, b: int) -> int {
+    var result: int = (a + b);
+    return result;
+}
+
+fun greet(name: string) -> string {
+    return name;
+}

--- a/tests/fixtures/valid/semantic_inferred.dub
+++ b/tests/fixtures/valid/semantic_inferred.dub
@@ -1,0 +1,13 @@
+// Type inference with un-annotated parameters.
+fun identity(x) {
+    return x;
+}
+
+fun apply(f, x) {
+    return f(x);
+}
+
+fun compose(a, b) {
+    var result = (a + b);
+    return result;
+}

--- a/tests/fixtures/valid/semantic_struct_method.dub
+++ b/tests/fixtures/valid/semantic_struct_method.dub
@@ -1,0 +1,13 @@
+// Struct with method accessing fields.
+type counter = struct {
+    value: int;
+}
+
+fun counter::get() -> int {
+    return value;
+}
+
+fun counter::add(n: int) -> int {
+    value = (value + n);
+    return value;
+}


### PR DESCRIPTION
## Summary

- Add a full semantic analysis pipeline: name resolution → type inference → type checking, wired between parsing and printing
- Implement Hindley-Milner unification engine with Rémy-style row types for structural subtyping (structs = closed rows, interfaces = open rows)
- Add Type IR hierarchy (`type_t` with 8 concrete types), scoped symbol table, diagnostics with error/warning severity, and `--no-check` flag
- Source locations (`int line`) on all AST nodes via `loc()` template in parser, enabling error messages like `line 14: error: duplicate type name 'point'`

## Tests

- Fixtures added: `semantic_basic.dub`, `semantic_struct_method.dub`, `semantic_inferred.dub` (valid roundtrip); `duplicate_type.dub`, `duplicate_func.dub` (error)
- All existing tests pass: `ninja -C build test` (46/46)

🤖 Generated with [Claude Code](https://claude.com/claude-code)