### PR TITLE
refactor(main): replace manual argv parsing with argparse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build System
 
-This project uses **Meson** with **Clang** (required — the build will error if another compiler is detected). Flex and **Bison ≥ 3.0** are also required. C++20 is used. On macOS the system Bison (2.x) is too old; install a newer version via Homebrew (`brew install bison`). Meson will detect it automatically via the Homebrew opt path.
+This project uses **Meson** with **Clang** (required — the build will error if another compiler is detected). Flex and **Bison ≥ 3.0** are also required. C++20 is used. On macOS the system Bison (2.x) is too old; install a newer version via Homebrew (`brew install bison`). Meson will detect it automatically via the Homebrew opt path. CLI argument parsing uses [argparse](https://github.com/p-ranav/argparse) (v3.2, header-only, fetched automatically via Meson WrapDB).
 
 ```bash
 # Configure (first time or after meson.build changes)
@@ -49,7 +49,7 @@ The `--no-check` flag skips the resolver and type checker passes.
 - `symbol_table.h` / `symbol_table.cpp` — Scoped symbol table (`push_scope`/`pop_scope`/`bind`/`lookup`) and type registry (`register_type`/`lookup_type`) with function registry.
 - `resolver.h` / `resolver.cpp` — Name resolution visitor. Two sub-passes: (1) register all type names, (2) fill in struct fields, interface methods, function signatures, resolve inheritance. Structs become closed rows, interfaces become open rows.
 - `type_checker.h` / `type_checker.cpp` — Type inference visitor. Infers expression types via HM unification, binds variables in scoped symbol table, checks function/method bodies. Expression types are stored in a side table (`unordered_map<const ast_node*, type_ptr>`) to avoid modifying AST node classes. Method bodies have implicit access to their struct's fields. Generalization at top-level function boundaries.
-- `main.cpp` — Entry point: opens a file, calls `yyparse()`, runs resolver + type checker (unless `--no-check`), then calls `printer` on the AST root.
+- `main.cpp` — Entry point: uses [argparse](https://github.com/p-ranav/argparse) for CLI parsing (`--no-check`, positional input file), opens the file, calls `yyparse()`, runs resolver + type checker (unless `--no-check`), then calls `printer` on the AST root.
 
 ### Build-generated files (`build/src/`)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include <cstring>
+#include <argparse/argparse.hpp>
 #include <filesystem>
 #include <format>
 #include <fstream>
@@ -33,24 +33,23 @@ using unique_lex_buffer = std::unique_ptr<yy_buffer_state, lex_buffer_deleter>;
 }  // namespace
 
 int main(int argc, char** argv) {
-    bool no_check = false;
-    const char* input_file = nullptr;
+    argparse::ArgumentParser program("dubsar", "0.1.0");
+    program.add_argument("input-file").help("source file to compile");
+    program.add_argument("--no-check")
+        .help("skip type checking (parse and print only)")
+        .default_value(false)
+        .implicit_value(true);
 
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--no-check") == 0) {
-            no_check = true;
-        } else if (input_file == nullptr) {
-            input_file = argv[i];
-        } else {
-            std::cerr << std::format("Usage: {} [--no-check] <input-file>\n", argv[0]);
-            return 1;
-        }
-    }
-
-    if (input_file == nullptr) {
-        std::cerr << std::format("Usage: {} [--no-check] <input-file>\n", argv[0]);
+    try {
+        program.parse_args(argc, argv);
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << '\n';
+        std::cerr << program;
         return 1;
     }
+
+    auto input_file = program.get<std::string>("input-file");
+    auto no_check = program.get<bool>("--no-check");
 
     const std::filesystem::path input_path{input_file};
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,8 @@ generated_lib = static_library('generated',
     cpp_args: ['-Wno-error', '-w'],
 )
 
+argparse_dep = dependency('argparse')
+
 dubsar = executable('dubsar',
     'main.cpp',
     'ast.cpp',
@@ -37,6 +39,7 @@ dubsar = executable('dubsar',
     'resolver.cpp',
     'type_checker.cpp',
     include_directories: src_inc,
+    dependencies: argparse_dep,
     link_with: generated_lib,
     install: false
 )

--- a/subprojects/argparse.wrap
+++ b/subprojects/argparse.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = argparse-3.2
+source_url = https://github.com/p-ranav/argparse/archive/refs/tags/v3.2.tar.gz
+source_filename = argparse-3.2.tar.gz
+source_hash = 9dcb3d8ce0a41b2a48ac8baa54b51a9f1b6a2c52dd374e28cc713bab0568ec98
+patch_filename = argparse_3.2-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/argparse_3.2-2/get_patch
+patch_hash = 46a7f697beacf0ecdd56d430bd0707dea0311fa3ff8e0ebfe9e6188d48e6a96b
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/argparse_3.2-2/argparse-3.2.tar.gz
+wrapdb_version = 3.2-2
+
+[provide]
+argparse = argparse_dep


### PR DESCRIPTION
## Summary

- Replace hand-rolled `argc`/`argv` loop in `main.cpp` with [p-ranav/argparse](https://github.com/p-ranav/argparse) (v3.2, header-only via Meson WrapDB)
- Adds auto-generated `--help` and `--version` flags; scales cleanly as more CLI options are added
- Update CLAUDE.md to document the new dependency and revised `main.cpp` description

## Tests

- Fixtures added: none
- All existing tests pass: `ninja -C build test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)